### PR TITLE
ci: build and test on beta channel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,9 @@ concurrency:
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
   workflow_dispatch:
 
 jobs:
@@ -16,40 +16,46 @@ jobs:
     runs-on: ubuntu-latest
     name: Check formatting
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Setup rust toolchain
-      uses: ./.github/actions/setup-rust
+      - name: Setup rust toolchain
+        uses: ./.github/actions/setup-rust
 
-    - name: Check formatting (rustfmt)
-      run: cargo fmt --all --check
+      - name: Check formatting (rustfmt)
+        run: cargo fmt --all --check
 
   build:
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        toolchain: [stable, beta]
     name: Build test
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Setup rust toolchain
-      uses: ./.github/actions/setup-rust
+      - name: Setup rust toolchain
+        uses: ./.github/actions/setup-rust
+        with:
+          toolchain: ${{ matrix.toolchain }}
 
-    - name: Build test
-      run: cargo check --profile=dev
+      - name: Build test
+        run: cargo check --profile=dev
 
   test:
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        toolchain: [stable, beta]
     name: Test
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Setup rust toolchain
-      uses: ./.github/actions/setup-rust
+      - name: Setup rust toolchain
+        uses: ./.github/actions/setup-rust
+        with:
+          toolchain: ${{ matrix.toolchain }}
 
-    - name: Build test
-      run: cargo test --profile=dev
+      - name: Build test
+        run: cargo test --profile=dev


### PR DESCRIPTION
## Why is this needed?

Building and testing with the beta channel and help us reduce the risk of breaking change when bumping the version of rust and its toolchains.

## What does this PR change?

- Add a toolchain entry with stable and beta to the matrix of build and test and use them to setup rust