### PR TITLE
chore: add PR, feature request and bug report templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,44 @@
+name: Bug report
+description: Report a bug or unexpected behavior
+labels: [ bug ]
+body:
+  - type: textarea
+    attributes:
+      label: Description
+      description: A clear and concise description of the bug.
+      placeholder: Describe the bug you've encountered.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Steps to Reproduce
+      description: Steps to reproduce the issue.
+      placeholder: |
+        1. Go to '...'
+        2. Click on '...'
+        3. See error
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Expected Behavior
+      description: Describe what should have happened.
+      placeholder: Explain the correct behavior you expected.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Additional Information
+      description: Any other context or related issues?
+      placeholder: |
+        Provide any other relevant information such as:
+        - Logs or error messages
+        - Your OS and architecture (e.g., Ubuntu 22.04, x86_64)
+        - Your Rust version (if built from source)
+        - The wasmedgeup version you're using
+    validations:
+      required: false
+

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,31 @@
+name: Feature request
+description: Request a feature or enhancement
+labels: [ enhancement ]
+body:
+  - type: textarea
+    attributes:
+      label: Description
+      placeholder: A clear and concise description of what you're requesting.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Proposed Solution
+      placeholder: A clear and concise description of how this feature should work.
+    validations:
+      required: false
+
+  - type: textarea
+    attributes:
+      label: Alternative Solution(s)
+      placeholder: Have you considered other ways to achieve the same goal? Describe them here.
+    validations:
+      required: false
+
+  - type: textarea
+    attributes:
+      label: Additional Information
+      placeholder: Related issues, screenshots, references, or anything else that helps understand the request.
+    validations:
+      required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+## Which GitHub issue does this PR close?
+
+Closes <!-- Add issue number here, e.g., Closes #123 -->
+
+## Why is this needed?
+
+<!-- Briefly explain the motivation behind this change. -->
+
+## What does this PR change?
+
+<!-- Summarize the key changes included in this PR. -->
+
+## How has this been tested?
+
+<!-- Describe the testing process. If no tests were added, explain why (e.g., already covered, not applicable). -->
+
+## Anything else?
+
+<!-- Include screenshots, documentation updates, or anything else relevant. -->


### PR DESCRIPTION
## Why is this needed?

With templates, contributors can make a brief overview of their needs/changes more easily.

## What does this PR change?

This PR adds a PR template, a feature request issue template, and a bug report issue template.