### PR TITLE
docs: add README, LICENSE and specification for wasmedgeup tool

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+# WasmEdgeUp
+
+Note: This project is still in development and not yet ready for use.
+
+`wasmedgeup` is a command-line tool for managing WasmEdge runtime installations and plugins across different operating systems and architectures.
+
+## Features
+
+- **Install** and **remove** specific versions of the WasmEdge runtime
+- **List** available WasmEdge runtime versions
+- **Install**, **list**, and **remove** WasmEdge plugins
+- Automatic cross-OS and cross-architecture detection
+- Checksum verification for secure downloads
+
+## Installation
+
+*Coming soon*
+
+## Usage
+
+Please refer to the [specification](spec.md) for detailed usage instructions.
+
+## License
+
+This project is licensed under the Apache License 2.0 - see the [LICENSE](LICENSE) file for details.

--- a/spec.md
+++ b/spec.md
@@ -1,0 +1,221 @@
+## Spec
+
+`wasmedgeup` will be a self-contained and static binary written in Rust that can:
+
+1. **Install** and **remove** specific versions of the WasmEdge runtime.
+2. **List** available WasmEdge runtime versions.
+3. **Install**, **list**, and **remove** WasmEdge plugins.
+4. Handle cross-OS and cross-architecture detection automatically, unless overridden by explicit flags.
+5. Use checksum to ensure safe downloads.
+
+### WasmEdge runtime
+
+#### Commands
+
+wasmedgeup should have the following commands:
+
+1. `install`: Installs a specified (or latest) WasmEdge runtime version.
+2. `list`: Lists all available WasmEdge releases.
+3. `remove`: Uninstalls a specific version of WasmEdge from the system, removing installed files.
+4. `help`: Shows a usage overview or help message for each subcommand.
+
+##### Command `Install`
+
+###### Arguments
+
+1. `install latest`: Installs the latest WasmEdge released version.
+2. `install <specific version, e.g. 0.14.1>`: Installs the specified version, e.g. `0.14.1`, `0.14.1-rc.1`, etc.
+
+###### Options
+
+- `-p`, `--path`
+  -  Description: Set the installed location
+  -  Usage: `--path /usr/local`
+  -  Default: `$HOME/.wasmedge`
+- `-t`, `--tmpdir`
+  -  Description: Set the temporary directory for staging downloaded assets
+  -  Usage: `--tmpdir /tmp`
+  -  Default: `/tmp`
+- `-o`, `--os`
+  -  Description: Overwrite the OS detection. If omitted, `wasmedgeup` auto-detects.
+  -  Usage: `--os Darwin`
+  -  Possible values: `Linux`, `Darwin` (macOS), `Windows`, or distro-specific like `Ubuntu`.
+- `-a`, `--arch`
+  -  Description: Overwrite the ARCH detection. If omitted, `wasmedgeup` auto-detects.
+  -  Usage: `--arch aarch64`
+  -  Possible values: `x86_64`, `arm64`, `aarch64` (where `arm64` is synonymous with `aarch64`).
+
+#### Global Options
+
+1. `-v`, `--version`: Prints wasmedgeup installer version (not the runtime)
+2. `-V`, `--verbose`: Enables verbose output
+3. `-q`, `--quite`: Disables progress output
+
+#### Internal Behavior / OS & ARCH Detection
+
+When no OS or ARCH flags are provided, `wasmedgeup` should detect the operating systems and the architectures automatically.
+
+1. ARCH: "x86_64", "arm64", "aarch64". Please note that "arm64" equals "aarch64".
+2. OS: Typically one of:
+  - "Ubuntu"
+  - "Linux": generic for most distributions besides "Ubuntu"
+  - "Darwin": macOS
+  - "Windows"
+
+If ARCH and OS are not matched to the above list, `wasmedgeup` should raise an error and refuse to proceed.
+
+#### Examples
+
+```bash
+# List versions
+$ wasmedgeup list
+0.15.0 <- latest
+0.14.1
+0.14.1-rc.1
+0.14.1-beta.2
+0.14.1-alpha.3
+0.14.0
+0.13.5
+
+# Install latest
+$ wasmedgeup install latest
+... installing 0.15.0
+
+# Install a specific version
+$ wasmedgeup install 0.13.5-rc.1
+... installing 0.13.5-rc.1
+
+# Override OS and ARCH
+$ wasmedgeup install 0.15.0 -p /usr/local -t /tmp -o Darwin -a aarch64
+... installing 0.15.0 with the following config: (Darwin, aarch64) to /usr/local via /tmp
+
+# Ubuntu + x86_64
+$ wasmedgeup install latest --path /usr/local --tmpdir /tmp --os Ubuntu --arch x86_64
+... installing latest(0.15.0) with the following config: (Ubuntu, x86_64) to /usr/local via /tmp
+```
+
+### WasmEdge plugins
+
+Just as with the runtime installation, `wasmedgeup` should manage plugins in a uniform way.
+
+#### Commands `plugin`
+
+1. `install`: Installs the specific WasmEdge plugins.
+2. `list`: Lists all available WasmEdge plugins according to the installed WasmEdge runtime version
+3. `remove`: Uninstalls the specific WasmEdge plugins
+
+##### Command `install`
+
+1. `install package`: Install the given plugin, e.g. `wasi-nn-ggml`
+2. `install package_1 package_2 ...`: Install multiple given plugins, split by space
+3. `install package@version`: Install the given plugin with specific version
+
+- Steps:  
+  1. Checks the currently installed WasmEdge runtime version (e.g., `0.15.0`).
+  2. Retrieves the plugin manifest JSON from links, described below.
+  3. Resolves the best matching plugin binaries for the user’s OS, ARCH, and runtime version.
+  4. Downloads, verifies, and installs them into the WasmEdge plugin directory (e.g., `$HOME/.wasmedge/plugins`).
+
+##### Command `remove`
+
+Just remove the installed plugins.
+
+1. `remove package`: Remove the given plugin, e.g. `wasi-nn-ggml`
+2. `remove package_1 package_2 ...`: Remove multiple given plugins, split by space
+3. `remove package@version`: remove the given plugin with specific version
+
+##### Command `list`
+
+Show all avaliable plugins. We will provide several manifests for it.
+Assuming there are two repositories called `wasmedge/cpp_plugins` and `wasmedge/rust_plugins`.
+Both of them provide a branch or tag called `latest`. So the installer can always retrieve the list via the following two links:
+1. `https://github.com/WasmEdge/cpp_plugins/releases/download/latest/version.json`
+2. `https://github.com/WasmEdge/rust_plugins/releases/download/latest/version.json`
+
+The content of these version.json provide:
+
+```json
+{
+   "maintained": ["0.14.1", "0.15.0"]
+   "deprecated": ["0.13.0", "0.13.1", "0.13.2", "0.13.3", "0.13.4", "0.13.5", "0.14.0"]
+}
+```
+
+Assuming we will have the following branches/tags called `<wasmedge_runtime_versions>`. So the installer can always retrieve the plugin information via the following links:
+1. `https://github.com/WasmEdge/cpp_plugins/releases/download/0.15.0/version.json`
+2. `https://github.com/WasmEdge/rust_plugins/releases/download/0.14.1/version.json`
+
+The content of these version.json provide:
+
+```json
+{
+    "<plugin_name>": {
+        "<version>": {
+            "deps": []
+            "platform": [
+                "manylinux_2_28_x86_64",
+                "manylinux_2_28_aarch64",
+                "ubuntu20_04_x86_64",
+                "ubuntu20_04_aarch64",
+                "darwin_x86_64",
+                "darwin_arm64",
+                "windows_x86_64"
+            ]
+        },
+        "<version>": {
+            "deps": []
+            "platform": [
+                "manylinux_2_28_x86_64",
+                "manylinux_2_28_aarch64",
+                "ubuntu20_04_x86_64",
+                "ubuntu20_04_aarch64",
+                "darwin_x86_64",
+                "darwin_arm64",
+                "windows_x86_64"
+            ]
+        }
+    },
+    "wasi-nn-ggml": {
+        "0.1.18": {
+            "deps": []
+            "platform": [
+                "manylinux_2_28_x86_64",
+                "manylinux_2_28_aarch64",
+                "ubuntu20_04_x86_64",
+                "ubuntu20.04_x86_64",
+                "ubuntu20_04_aarch64",
+                "windows_x86_64"
+            ]
+        }
+    }
+}
+```
+
+Assuming the plugin assets has their own release tag like the following format:
+1. `https://github.com/WasmEdge/cpp_plugins/releases/download/<plugin_name>-<wasmedge_runtime_version>-<plugin_version>`
+2. `https://github.com/WasmEdge/rust_plugins/releases/download/<plugin_name>-<wasmedge_runtime_version>-<plugin_version>`
+
+So the installer can access these assets via composing the link:
+1. `https://github.com/WasmEdge/cpp_plugins/releases/download/wasi-nn-ggml-0.15.0-0.1.18`
+2. `https://github.com/WasmEdge/rust_plugins/releases/download/wasi-xxx-0.14.1-0.6.4`
+
+#### Examples
+
+```bash
+# List plugins, assuming installed wasmedge 0.15.0, os is Darwin, and arch is aarch64
+wasmedgeup plugin list
+wasi-nn-ggml 0.1.18
+wasi-nn-ggml 0.1.19
+wasi-windows-ext 0.2.0 [Not compatible, provides (Windows, x86_64)]
+...
+
+# Install plugins
+wasmedgeup plugin install wasmedge-tensorflow-lite # WasmEdge TensorFlow Lite plugin
+wasmedgeup plugin install wasmedge-image@0.2.0 # WasmEdge Image plugin
+wasmedgeup plugin install wasi-nn-ggml wasi-nn-whisper # WasmEdge WASI NN plugins
+
+# Remove plugins
+wasmedgeup plugin remove wasmedge-tensorflow-lite
+wasmedgeup plugin remove wasmedge-image@0.2.0
+wasmedgeup plugin remove wasi-nn-ggml wasi-nn-whisper
+```


### PR DESCRIPTION
## Which GitHub issue does this PR close?

Closes #6 

## Why is this needed?

The README and LICENSE are missing

## What does this PR change?

Provides README and LICENSE information.

## How has this been tested?

No need to test.

## Anything else?

None.