### PR TITLE
ci: add paths filter to avoid unnecessary runs

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Rust
 
 concurrency:
   group: ${{ github.repository }}-${{ github.head_ref || github.sha }}-${{ github.workflow }}
@@ -7,8 +7,14 @@ concurrency:
 on:
   push:
     branches: [master]
+    paths-ignore:
+      - "**.md"
+      - ".github/ISSUE_TEMPLATE/**"
   pull_request:
     branches: [master]
+    paths-ignore:
+      - "**.md"
+      - ".github/ISSUE_TEMPLATE/**"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Why is this needed?

Currently the Rust-related CI pipeline runs on PR and push to master regardless of the change even if it only update docs.

## What does this PR change?

This PR add the `paths-ignore` filter on `pull_request` and `push` events.

## Anything else?

Also changed the "CI" pipeline to "Rust" pipeline