### PR TITLE
feat(ci): add CI integration with Knope

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -6,6 +6,9 @@ inputs:
     description: Toolchain name, such as 'stable', 'nightly', or '1.8.0'
     required: true
     default: stable
+  target:
+    description: Build target name, such as 'x86_64-unknown-linux-gnu', 'aarch64-apple-darwin', or 'x86_64-pc-windows-msvc'
+    required: false
 
 runs:
   using: composite
@@ -15,6 +18,11 @@ runs:
       run: |
         rustup toolchain install ${{ inputs.toolchain }} --profile default
         rustup default ${{ inputs.toolchain }}
+
+    - name: Add build target
+      if: "${{ inputs.target != '' }}"
+      shell: bash
+      run: rustup target add ${{ inputs.target }}
 
     - uses: mozilla-actions/sccache-action@v0.0.7
 

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -1,0 +1,30 @@
+name: Create Release PR
+
+on:
+  push:
+    branches: [master]
+
+jobs:
+  prepare-release:
+    if: "!contains(github.event.head_commit.message, 'chore: prepare release')" # Skip merge events from releases
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config --global user.name GitHub Actions
+          git config user.email github-actions@github.com
+
+      - uses: knope-dev/action@v2
+        with:
+          version: 0.18.5
+
+      - name: Prepare Release
+        run: knope prepare-release --verbose
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,103 @@
+name: Release
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [master]
+
+jobs:
+  build-artifacts:
+    if: github.head_ref == 'release' && github.event.pull_request.merged == true
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x84_64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: x84_64-unknown-linux-musl
+            os: ubuntu-latest
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: aarch64-unknown-linux-musl
+            os: ubuntu-latest
+          - target: x86_64-apple-darwin
+            os: macos-latest
+          - target: aarch64-apple-darwin
+            os: macos-latest
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+    env:
+      package_name: wasmedgeup
+
+    runs-on: ${{ matrix.os }}
+    name: ${{ matrix.target }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup rust toolchain
+        uses: ./.github/actions/setup-rust
+        with:
+          target: ${{ matrix.target }}
+
+      - name: Install musl-tools
+        if: "${{ matrix.target == 'x86_64-unknown-linux-musl' || matrix.target == 'aarch64-unknown-linux-musl' }}"
+        run: sudo apt-get install -y musl-tools
+
+      - name: Build
+        run: cargo build --release --target ${{ matrix.target }}
+
+      - name: Set archive name (non-windows)
+        id: archive
+        run: echo "archive_name=${{ env.package_name }}-${{ matrix.target }}" >> $GITHUB_ENV
+
+      - name: Set archive name (windows)
+        if: "${{ matrix.os == 'windows-latest' }}"
+        run: echo "archive_name=${{ env.package_name }}-${{ matrix.target }}" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
+
+      - name: Create Archive Folder
+        run: mkdir ${{ env.archive_name }}
+
+      - name: Copy Unix Artifact
+        if: "${{ matrix.os != 'windows-latest' }}"
+        run: cp target/${{ matrix.target }}/release/${{ env.package_name }} ${{ env.archive_name }}
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.target }}
+          path: ${{ env.archive_name }}.tgz
+          if-no-files-found: error
+
+  release:
+    needs: [build-artifacts]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      - uses: knope-dev/action@v2
+        with:
+          version: 0.18.5
+
+      - run: knope release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  publish-crate:
+    needs: [release]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup rust toolchain
+        uses: ./.github/actions/setup-rust
+
+      - uses: katyo/publish-crate@v2
+        with:
+          registry-token: ${{ secrets.CARGO_TOKEN }}

--- a/knope.toml
+++ b/knope.toml
@@ -1,0 +1,48 @@
+[package]
+versioned_files = ["Cargo.toml", "Cargo.lock"]
+changelog = "CHANGELOG.md"
+assets = "artifacts/*"
+
+[[workflows]]
+name = "prepare-release"
+
+[[workflows.steps]]
+type = "Command"
+command = "git switch -c release"
+
+[[workflows.steps]]
+type = "PrepareRelease"
+allow_empty = true
+
+[[workflows.steps]]
+type = "Command"
+command = "git commit -m \"chore: prepare release $version\""
+
+[[workflows.steps]]
+type = "Command"
+command = "git push --force-with-lease --set-upstream origin release"
+
+[workflows.steps.variables]
+"$version" = "Version"
+
+[[workflows.steps]]
+type = "CreatePullRequest"
+base = "master"
+
+[workflows.steps.title]
+template = "chore: prepare release $version"
+variables = { "$version" = "Version" }
+
+[workflows.steps.body]
+template = """\
+This PR was created by [Knope](https://knope.tech/). Merging it will create a new release.
+
+# Releases
+
+$changelog\
+"""
+variables = { "$changelog" = "ChangelogEntry" }
+
+[github]
+owner = "WasmEdge"
+repo = "wasmedgeup"


### PR DESCRIPTION
## Why is this needed?

To streamline release management and automate version tracking, we've decided to integrate [Knope](https://knope.tech/) after discussion. This will help automate changelog generation, version bumps, and publishing.

## What does this PR change?

- Adds a `knope.toml` configuration file.  
- Adds two new GitHub Actions workflows:
  - `prepare_release`: triggers when any PR (except release PRs) is merged into the `master` branch. Knope will automatically create a PR titled `chore: prepare release {version}` to preview the upcoming release.
  - `release`: triggers when the prepare release PR is merged. It builds the project, creates a GitHub release, and publishes the crate to `crates.io` (for easier `cargo install` usage).
  
    Build platforms:
	- Linux (x86_64, aarch64) — both gnu and musl
	- macOS (x86_64, aarch64)
	- Windows (x86_64-msvc)
    

## How has this been tested?

I haven’t yet validated the workflows since there's no simple way to do it, but I’ve verified syntax and reviewed Knope’s documentation. Suggestions on better ways to test these CI changes are welcome!

## Anything else?

- Both workflows require a GitHub token with `contents: write` permissions in order to create PRs, which I’ve set via the `permissions` field in the respective jobs. However, feedback on this setup would be appreciated.
- The `release.yml` workflow requires a `CARGO_TOKEN` secret to publish the crate to `crates.io`.