### PR TITLE
ci: audit check

### DIFF
--- a/.github/workflows/audit_check.yml
+++ b/.github/workflows/audit_check.yml
@@ -1,0 +1,16 @@
+name: Security audit
+
+on:
+  push:
+    paths:
+      - "**/Cargo.toml"
+      - "**/Cargo.lock"
+
+jobs:
+  security-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: rustsec/audit-check@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Which GitHub issue does this PR close?

## Why is this needed?

Add audit pipeline for scanning security issues in dependencies.

## What does this PR change?

Integrate the [rustsec/audit-check](https://github.com/rustsec/audit-check) action.

## How has this been tested?

N/A

## Anything else?

No.
