### PR TITLE
fix: knope action version

### DIFF
--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -20,7 +20,7 @@ jobs:
           git config --global user.name GitHub Actions
           git config user.email github-actions@github.com
 
-      - uses: knope-dev/action@v2
+      - uses: knope-dev/action@v2.1.0
         with:
           version: 0.18.5
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,7 +85,7 @@ jobs:
           path: artifacts
           merge-multiple: true
 
-      - uses: knope-dev/action@v2
+      - uses: knope-dev/action@v2.1.0
         with:
           version: 0.18.5
 


### PR DESCRIPTION
## Which GitHub issue does this PR close?

Closes <!-- Add issue number here, e.g., Closes #123 -->

## Why is this needed?

In #12, we specified `knope-dev/action@v2`. However, this version does not exist.

## What does this PR change?

Change `knope-dev/action@v2` to `knope-dev/action@v2.1.0`

## How has this been tested?

<!-- Describe the testing process. If no tests were added, explain why (e.g., already covered, not applicable). -->

## Anything else?

<!-- Include screenshots, documentation updates, or anything else relevant. -->
