### PR TITLE
fix(gha): update `mozilla-actions/sccache-action` to v0.0.8

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -24,7 +24,7 @@ runs:
       shell: bash
       run: rustup target add ${{ inputs.target }}
 
-    - uses: mozilla-actions/sccache-action@v0.0.7
+    - uses: mozilla-actions/sccache-action@v0.0.8
 
     - name: Setup rust cache variables
       shell: bash

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/.github/actions/setup-rust"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Which GitHub issue does this PR close?

Closes <!-- Add issue number here, e.g., Closes #123 -->

## Why is this needed?

GitHub Actions cache spec changed, so the CI pipelines cannot work properly with the current configuration.

## What does this PR change?

- Update `mozilla-actions/sccache-action` to v0.0.8
- Update dependabot configuration so that it also scans actions used by the `setup-rust` composite action (see dependabot/dependabot-core#6704), but I'm not very confident this works

## How has this been tested?

<!-- Describe the testing process. If no tests were added, explain why (e.g., already covered, not applicable). -->
N/A

## Anything else?

<!-- Include screenshots, documentation updates, or anything else relevant. -->
