### PR TITLE
feat: implement `wasmedgeup list` with libgit2

### DIFF
--- a/.changeset/add_wasmedgeup_list_command.md
+++ b/.changeset/add_wasmedgeup_list_command.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+# add `wasmedgeup list` command

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,6 +133,8 @@ version = "1.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "525046617d8376e3db1deffb079e91cef90a89fc3ca5c185bbf8c9ecdd15cd5c"
 dependencies = [
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -277,28 +279,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
- "futures-sink",
 ]
 
 [[package]]
@@ -306,23 +292,6 @@ name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
-
-[[package]]
-name = "futures-executor"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
-name = "futures-io"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-macro"
@@ -359,13 +328,9 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
- "futures-channel",
  "futures-core",
- "futures-io",
  "futures-macro",
- "futures-sink",
  "futures-task",
- "memchr",
  "pin-project-lite",
  "pin-utils",
  "slab",
@@ -399,6 +364,21 @@ name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+
+[[package]]
+name = "git2"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5220b8ba44c68a9a7f7a7659e864dd73692e417ef0211bea133c7b74e031eeb9"
+dependencies = [
+ "bitflags",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "openssl-probe",
+ "openssl-sys",
+ "url",
+]
 
 [[package]]
 name = "glob"
@@ -718,6 +698,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "jobserver"
+version = "0.1.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a"
+dependencies = [
+ "getrandom 0.3.2",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -732,6 +722,46 @@ name = "libc"
 version = "0.2.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
+
+[[package]]
+name = "libgit2-sys"
+version = "0.18.1+1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1dcb20f84ffcdd825c7a311ae347cce604a6f084a767dec4a4929829645290e"
+dependencies = [
+ "cc",
+ "libc",
+ "libssh2-sys",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+]
+
+[[package]]
+name = "libssh2-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "220e4f05ad4a218192533b300327f5150e809b54c4ec83b5a1d91833601811b9"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b70e7a7df205e92a1a4cd9aaae7898dac0aa555503cc0a649494d0d60e7651d"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -1621,9 +1651,7 @@ name = "wasmedgeup"
 version = "0.1.0"
 dependencies = [
  "clap",
- "futures",
- "pin-project-lite",
- "regex",
+ "git2",
  "reqwest",
  "rstest",
  "semver",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,7 @@ license = "Apache-2.0"
 
 [dependencies]
 clap = { version = "4.5.36", features = ["derive"] }
-futures = "0.3.31"
-pin-project-lite = "0.2.16"
-regex = "1.11.1"
+git2 = { version = "0.20.1", features = ["vendored-libgit2"] }
 reqwest = "0.12.15"
 semver = "1.0.26"
 snafu = "0.8.5"

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
-mod releases;
+pub mod releases;
 pub use releases::ReleasesFilter;
 
 use semver::Version;

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,34 +1,22 @@
 use crate::prelude::*;
-use futures::{StreamExt, TryStreamExt};
-use releases::Releases;
-use semver::Version;
-
 mod releases;
-
 pub use releases::ReleasesFilter;
 
+use semver::Version;
+
 #[derive(Debug, Clone, Default)]
-pub struct WasmEdgeApiClient {
-    client: reqwest::Client,
-}
+pub struct WasmEdgeApiClient {}
+
+const WASM_EDGE_GIT_URL: &str = "https://github.com/WasmEdge/WasmEdge.git";
 
 impl WasmEdgeApiClient {
-    pub async fn releases(
-        &self,
-        filter: ReleasesFilter,
-        num_releases: usize,
-    ) -> Result<Vec<Version>> {
-        Releases::new(self.client.clone(), filter)
-            .take(num_releases)
-            .try_collect()
-            .await
+    pub fn releases(&self, filter: ReleasesFilter, num_releases: usize) -> Result<Vec<Version>> {
+        let releases = releases::get_all(WASM_EDGE_GIT_URL, filter)?;
+        Ok(releases.into_iter().take(num_releases).collect())
     }
 
-    pub async fn latest_release(&self) -> Result<Version> {
-        Releases::new(self.client.clone(), ReleasesFilter::Stable)
-            .try_next()
-            .await
-            .transpose()
-            .unwrap_or(Err(Error::Unknown))
+    pub fn latest_release(&self) -> Result<Version> {
+        let releases = releases::get_all(WASM_EDGE_GIT_URL, ReleasesFilter::Stable)?;
+        releases.into_iter().next().ok_or(Error::Unknown)
     }
 }

--- a/src/api/releases.rs
+++ b/src/api/releases.rs
@@ -1,129 +1,8 @@
+use git2::{Direction, Remote, RemoteHead};
+use semver::Version;
+use snafu::ResultExt as _;
+
 use crate::prelude::*;
-use std::{
-    pin::Pin,
-    sync::OnceLock,
-    task::{Context, Poll},
-};
-
-use futures::{future::BoxFuture, Stream};
-use pin_project_lite::pin_project;
-use regex::Regex;
-use reqwest::StatusCode;
-use snafu::ResultExt;
-
-const RELEASES_URL: &str = "https://github.com/WasmEdge/WasmEdge/releases";
-
-static RELEASE_TAG_REGEX: OnceLock<Regex> = OnceLock::new();
-
-fn release_tag_regex() -> &'static Regex {
-    RELEASE_TAG_REGEX.get_or_init(|| {
-        Regex::new(r"releases\/tag\/(?<version>[0-9]+\.[0-9]+\.[0-9]+(\-[[:alpha:]]+\.[0-9]+)?)")
-            .expect("release tag regex should be valid")
-    })
-}
-
-pin_project! {
-    pub struct Releases<'a> {
-        client: reqwest::Client,
-        filter: ReleasesFilter,
-        current_page: usize,
-        current_start: usize,
-
-        #[pin]
-        state: State<'a>
-    }
-}
-
-enum State<'a> {
-    Ready,
-    Loading(BoxFuture<'a, reqwest::Result<String>>),
-    Fetched(String),
-}
-
-impl<'a> Releases<'a> {
-    pub fn new(client: reqwest::Client, filter: ReleasesFilter) -> Self {
-        Self {
-            client,
-            filter,
-            current_page: 1,
-            current_start: 0,
-            state: State::Ready,
-        }
-    }
-
-    fn fetch_releases(&mut self, page: usize) -> BoxFuture<'a, reqwest::Result<String>> {
-        let client = self.client.clone();
-
-        Box::pin(async move {
-            client
-                .get(RELEASES_URL)
-                .query(&[("page", page)])
-                .send()
-                .await?
-                .text()
-                .await
-        })
-    }
-}
-
-impl<'a> Stream for Releases<'a> {
-    type Item = Result<semver::Version>;
-
-    fn poll_next(self: Pin<&mut Releases<'a>>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        let this = self.get_mut();
-
-        loop {
-            match &mut this.state {
-                State::Ready => {
-                    let fut = this.fetch_releases(this.current_page);
-                    this.state = State::Loading(fut);
-                }
-                State::Loading(fut) => match futures::ready!(fut.as_mut().poll(cx)) {
-                    Err(e) if matches!(e.status(), Some(StatusCode::NOT_FOUND)) => {
-                        return Poll::Ready(None)
-                    }
-                    Err(e) => {
-                        return Poll::Ready(Some(Err(e).context(GitHubSnafu {
-                            resource: "releases",
-                        })))
-                    }
-                    Ok(s) => {
-                        this.state = State::Fetched(s);
-                    }
-                },
-                State::Fetched(ref html) => {
-                    let Some(caps) = release_tag_regex().captures_at(html, this.current_start)
-                    else {
-                        this.current_start = 0;
-                        this.current_page += 1;
-                        this.state = State::Ready;
-                        continue;
-                    };
-
-                    let version = caps.name("version").unwrap();
-                    let parsed_version = version.as_str().parse().context(SemVerSnafu {})?;
-                    this.current_start = version.end();
-
-                    if !this.filter.matches(&parsed_version) {
-                        continue;
-                    }
-
-                    return Poll::Ready(Some(Ok(parsed_version)));
-                }
-            }
-        }
-    }
-}
-
-impl std::fmt::Debug for State<'_> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Ready => write!(f, "Ready"),
-            Self::Loading(_) => write!(f, "Loading(...)"),
-            Self::Fetched(s) => f.debug_tuple("Fetched").field(s).finish(),
-        }
-    }
-}
 
 #[derive(Debug, Clone, Copy)]
 pub enum ReleasesFilter {
@@ -132,7 +11,7 @@ pub enum ReleasesFilter {
 }
 
 impl ReleasesFilter {
-    fn matches(self, semver: &semver::Version) -> bool {
+    pub fn matches(self, semver: &semver::Version) -> bool {
         match self {
             Self::All => true,
             Self::Stable => semver.pre.is_empty(),
@@ -140,46 +19,30 @@ impl ReleasesFilter {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use std::ops::Range;
+/// Get all releases sorted from newest to oldest.
+pub fn get_all(url: &str, filter: ReleasesFilter) -> Result<Vec<Version>> {
+    let mut remote = Remote::create_detached(url).context(GitSnafu { resource: "remote" })?;
+    remote.connect(Direction::Fetch).context(GitSnafu {
+        resource: "remote/connect",
+    })?;
 
-    use rstest::rstest;
+    let list = remote.list().context(GitSnafu {
+        resource: "remote/list",
+    })?;
+    let mut heads = list
+        .iter()
+        .filter_map(remote_head_to_version)
+        .filter(|version| filter.matches(version))
+        .collect::<Vec<_>>();
+    heads.sort_unstable_by(|a, b| b.cmp(a));
 
-    use super::*;
+    Ok(heads)
+}
 
-    #[rstest]
-    #[case::stable(r#"href="/WasmEdge/WasmEdge/releases/tag/1.0.0""#, "1.0.0", 38..43)]
-    #[case::alpha(r#"href="/WasmEdge/WasmEdge/releases/tag/1.0.0-alpha.1""#, "1.0.0-alpha.1", 38..51)]
-    #[case::beta(r#"href="/WasmEdge/WasmEdge/releases/tag/1.0.0-beta.1""#, "1.0.0-beta.1", 38..50)]
-    #[case::rc(r#"href="/WasmEdge/WasmEdge/releases/tag/1.0.0-rc.1""#, "1.0.0-rc.1", 38..48)]
-    #[case::any_prerelease(r#"href="/WasmEdge/WasmEdge/releases/tag/1.0.0-anyprerelease.1""#, "1.0.0-anyprerelease.1", 38..59)]
-    fn test_valid_semver_valid_release_tags(
-        #[case] input: &str,
-        #[case] expected_str: &str,
-        #[case] expected_range: Range<usize>,
-    ) {
-        let result = release_tag_regex().captures(input).unwrap();
-        let version = result.name("version").unwrap();
-        assert_eq!(version.as_str(), expected_str);
-        assert_eq!(version.range(), expected_range);
+fn remote_head_to_version(head: &'_ RemoteHead<'_>) -> Option<Version> {
+    let name = head.name().strip_prefix("refs/tags/")?;
+    if name.ends_with("^{}") {
+        return None;
     }
-
-    #[rstest]
-    #[case::prerelease_no_num(r#"href="/WasmEdge/WasmEdge/releases/tag/1.0.0-alpha""#, "1.0.0", 38..43)]
-    #[case::prerelease_no_alpha(r#"href="/WasmEdge/WasmEdge/releases/tag/1.0.0-0.3.7""#, "1.0.0", 38..43)]
-    #[case::prerelease_multiple(r#"href="/WasmEdge/WasmEdge/releases/tag/1.0.0-x.7.z.92""#, "1.0.0-x.7", 38..47)]
-    #[case::prerelease_hyphens(r#"href="/WasmEdge/WasmEdge/releases/tag/1.0.0-x-y-z.--""#, "1.0.0", 38..43)]
-    #[case::build_meta(r#"href="/WasmEdge/WasmEdge/releases/tag/1.0.0+20130313144700""#, "1.0.0", 38..43)]
-    #[case::prerelease_build_meta(r#"href="/WasmEdge/WasmEdge/releases/tag/1.0.0-alpha+001""#, "1.0.0", 38..43)]
-    fn test_valid_semver_partial_release_tags(
-        #[case] input: &str,
-        #[case] expected_str: &str,
-        #[case] expected_range: Range<usize>,
-    ) {
-        let result = release_tag_regex().captures(input).unwrap();
-        let version = result.name("version").unwrap();
-        assert_eq!(version.as_str(), expected_str);
-        assert_eq!(version.range(), expected_range);
-    }
+    Version::parse(name).ok()
 }

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -1,6 +1,5 @@
 use crate::{api::ReleasesFilter, cli::CommandContext, prelude::*};
 use clap::Parser;
-use tokio::join;
 
 use crate::cli::CommandExecutor;
 
@@ -19,13 +18,10 @@ impl CommandExecutor for ListArgs {
             ReleasesFilter::Stable
         };
 
-        let (gh_releases, latest_release) =
-            join!(ctx.client.releases(filter, 10), ctx.client.latest_release());
+        let releases = ctx.client.releases(filter, 10)?;
+        let latest_release = ctx.client.latest_release()?;
 
-        let gh_releases = gh_releases?;
-        let latest_release = latest_release?;
-
-        for gh_release in gh_releases.into_iter() {
+        for gh_release in releases.into_iter() {
             print!("{}", gh_release);
             if gh_release == latest_release {
                 println!(" <- latest");

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,9 +3,9 @@ use snafu::Snafu;
 #[derive(Debug, Default, Snafu)]
 #[snafu(visibility(pub))]
 pub enum Error {
-    #[snafu(display("Unable to fetch resource '{}' from GitHub", resource))]
-    GitHub {
-        source: reqwest::Error,
+    #[snafu(display("Unable to fetch resource '{}' for git", resource))]
+    Git {
+        source: git2::Error,
         resource: &'static str,
     },
 

--- a/tests/version_test.rs
+++ b/tests/version_test.rs
@@ -1,0 +1,55 @@
+use semver::Version;
+use wasmedgeup::api::{releases, ReleasesFilter};
+
+const WASM_EDGE_GIT_URL: &str = "https://github.com/WasmEdge/WasmEdge.git";
+
+#[test]
+fn test_retrieves_released_versions_stable() {
+    let retrieved = releases::get_all(WASM_EDGE_GIT_URL, ReleasesFilter::Stable).unwrap();
+
+    let pos_0_14_1 = retrieved
+        .iter()
+        .position(|v| v == &Version::new(0, 14, 1))
+        .unwrap();
+    let pos_0_14_0 = retrieved
+        .iter()
+        .position(|v| v == &Version::new(0, 14, 0))
+        .unwrap();
+    assert!(pos_0_14_1 < pos_0_14_0);
+
+    let pos_0_15_0_alpha_1 = retrieved
+        .iter()
+        .position(|v| v == &Version::parse("0.15.0-alpha.1").unwrap());
+    assert!(pos_0_15_0_alpha_1.is_none());
+
+    let pos_0_14_1_rc_2 = retrieved
+        .iter()
+        .position(|v| v == &Version::parse("0.14.1-rc.2").unwrap());
+    assert!(pos_0_14_1_rc_2.is_none());
+}
+
+#[test]
+fn test_retrieves_released_versions_all() {
+    let retrieved = releases::get_all(WASM_EDGE_GIT_URL, ReleasesFilter::All).unwrap();
+
+    let pos_0_15_0_alpha_1 = retrieved
+        .iter()
+        .position(|v| v == &Version::parse("0.15.0-alpha.1").unwrap())
+        .unwrap();
+    let pos_0_14_1 = retrieved
+        .iter()
+        .position(|v| v == &Version::new(0, 14, 1))
+        .unwrap();
+    let pos_0_14_1_rc_2 = retrieved
+        .iter()
+        .position(|v| v == &Version::parse("0.14.1-rc.2").unwrap())
+        .unwrap();
+    let pos_0_14_0 = retrieved
+        .iter()
+        .position(|v| v == &Version::new(0, 14, 0))
+        .unwrap();
+
+    assert!(pos_0_15_0_alpha_1 < pos_0_14_1);
+    assert!(pos_0_14_1 < pos_0_14_1_rc_2);
+    assert!(pos_0_14_1_rc_2 < pos_0_14_0);
+}


### PR DESCRIPTION
## Which GitHub issue does this PR close?

Closes <!-- Add issue number here, e.g., Closes #123 -->

## Why is this needed?

Current implementation of `wasmedgeup list` involves fetching HTML, using regex to find desired string, and semver parsing, which is a little complicated and slow.

## What does this PR change?

This PR uses [git2-rs](https://github.com/rust-lang/git2-rs) and simulates the actions behind `git ls-remote --refs --tags` to implement the listing command.

## How has this been tested?

Manually:

```
❯ cargo run -q list
0.14.1 <- latest
0.14.0
0.13.5
0.13.4
0.13.3
0.13.2
0.13.1
0.13.0
0.12.1
0.12.0
```

```
❯ cargo run -q list --all
0.15.0-alpha.1
0.14.1 <- latest
0.14.1-rc.5
0.14.1-rc.4
0.14.1-rc.3
0.14.1-rc.2
0.14.1-rc.1
0.14.1-beta.2
0.14.1-beta.1
0.14.0
```

## Anything else?

<!-- Include screenshots, documentation updates, or anything else relevant. -->
