### PR TITLE
feat: install WasmEdge to specified directory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -77,6 +88,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "arbitrary"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -116,16 +136,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+
+[[package]]
+name = "bzip2"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49ecfb22d906f800d4fe833b6282cf4dc1c298f5057ca0b5445e5c209735ca47"
+dependencies = [
+ "bzip2-sys",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.13+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
 
 [[package]]
 name = "cc"
@@ -143,6 +197,16 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
 
 [[package]]
 name = "clap"
@@ -191,6 +255,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "constant_time_eq"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -207,6 +290,113 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crc"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69e6e4d7b33a94f0991c26729976b10ebde1d34c3ee82408fb536164fa10d636"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+
+[[package]]
+name = "crc32fast"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "deflate64"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da692b8d1080ea3045efaab14434d40468c3d8657e42abddfffca87b428f4c1b"
+
+[[package]]
+name = "deranged"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -216,6 +406,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "encoding_rs"
@@ -247,6 +443,28 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "filetime"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35c0522e981e68cbfa8c3f978441a5f34b30b96e146b33cd3359176b50fe8586"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "flate2"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ced92e76e966ca2fd84c8f7aa01a4aea65b0eb6648d72f7c8f3e2764a67fece"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -337,6 +555,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -354,9 +582,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "wasi 0.14.2+wasi-0.2.4",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -416,6 +646,15 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "http"
@@ -680,6 +919,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.17.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
+dependencies = [
+ "console",
+ "number_prefix",
+ "portable-atomic",
+ "tokio",
+ "unicode-width",
+ "web-time",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -718,6 +980,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -735,6 +1003,17 @@ dependencies = [
  "libz-sys",
  "openssl-sys",
  "pkg-config",
+]
+
+[[package]]
+name = "libredox"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+dependencies = [
+ "bitflags",
+ "libc",
+ "redox_syscall",
 ]
 
 [[package]]
@@ -776,10 +1055,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
 
 [[package]]
+name = "lockfree-object-pool"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9374ef4228402d4b7e403e5838cb880d9ee663314b0a900d5a6aabf0c213552e"
+
+[[package]]
 name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+
+[[package]]
+name = "lzma-rs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "297e814c836ae64db86b36cf2a557ba54368d03f6afcd7d947c266692f71115e"
+dependencies = [
+ "byteorder",
+ "crc",
+]
+
+[[package]]
+name = "lzma-sys"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fda04ab3764e6cde78b9974eec4f779acaba7c4e84b36eca3cf77c581b85d27"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
+]
 
 [[package]]
 name = "memchr"
@@ -829,6 +1144,28 @@ dependencies = [
  "security-framework-sys",
  "tempfile",
 ]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "object"
@@ -890,6 +1227,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest",
+ "hmac",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -912,6 +1271,18 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "portable-atomic"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "proc-macro-crate"
@@ -947,6 +1318,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f103c6d277498fbceb16e84d317e2a400f160f46904d5f5410848c829511a3"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b"
+dependencies = [
+ "getrandom 0.2.15",
+ "libredox",
+ "thiserror",
+]
+
+[[package]]
 name = "regex"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -954,8 +1345,17 @@ checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata",
- "regex-syntax",
+ "regex-automata 0.4.9",
+ "regex-syntax 0.8.5",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -966,8 +1366,14 @@ checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.8.5",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -1149,6 +1555,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1231,10 +1646,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
 name = "slab"
@@ -1353,6 +1794,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tar"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1364,6 +1816,55 @@ dependencies = [
  "rustix",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "thiserror"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+]
+
+[[package]]
+name = "time"
+version = "0.3.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde",
+ "time-core",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
 
 [[package]]
 name = "tinystr"
@@ -1486,7 +1987,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1496,6 +2009,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -1505,10 +2048,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typenum"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "untrusted"
@@ -1546,10 +2101,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "want"
@@ -1650,13 +2227,24 @@ dependencies = [
 name = "wasmedgeup"
 version = "0.1.0"
 dependencies = [
+ "cfg-if",
  "clap",
+ "dirs",
+ "flate2",
  "git2",
+ "indicatif",
  "reqwest",
  "rstest",
  "semver",
  "snafu",
+ "tar",
+ "tempfile",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "url",
+ "walkdir",
+ "zip",
 ]
 
 [[package]]
@@ -1668,6 +2256,47 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"
@@ -1881,6 +2510,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
 
 [[package]]
+name = "xattr"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d65cbf2f12c15564212d48f4e3dfb87923d25d611f2aed18f4cb23f0413d89e"
+dependencies = [
+ "libc",
+ "rustix",
+]
+
+[[package]]
+name = "xz2"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
+dependencies = [
+ "lzma-sys",
+]
+
+[[package]]
 name = "yoke"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1930,6 +2578,20 @@ name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zerovec"
@@ -1951,4 +2613,74 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "zip"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dcb24d0152526ae49b9b96c1dcf71850ca1e0b882e4e28ed898a93c41334744"
+dependencies = [
+ "aes",
+ "arbitrary",
+ "bzip2",
+ "constant_time_eq",
+ "crc32fast",
+ "crossbeam-utils",
+ "deflate64",
+ "flate2",
+ "getrandom 0.3.2",
+ "hmac",
+ "indexmap",
+ "lzma-rs",
+ "memchr",
+ "pbkdf2",
+ "sha1",
+ "time",
+ "xz2",
+ "zeroize",
+ "zopfli",
+ "zstd",
+]
+
+[[package]]
+name = "zopfli"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5019f391bac5cf252e93bbcc53d039ffd62c7bfb7c150414d61369afe57e946"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "lockfree-object-pool",
+ "log",
+ "once_cell",
+ "simd-adler32",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.15+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb81183ddd97d0c74cedf1d50d85c8d08c1b8b68ee863bdee9e706eedba1a237"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1088,15 +1088,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "matchers"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
-dependencies = [
- "regex-automata 0.1.10",
-]
-
-[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1345,17 +1336,8 @@ checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.9",
- "regex-syntax 0.8.5",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
-dependencies = [
- "regex-syntax 0.6.29",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -1366,14 +1348,8 @@ checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.5",
+ "regex-syntax",
 ]
-
-[[package]]
-name = "regex-syntax"
-version = "0.6.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -2029,14 +2005,10 @@ version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
 dependencies = [
- "matchers",
  "nu-ansi-term",
- "once_cell",
- "regex",
  "sharded-slab",
  "smallvec",
  "thread_local",
- "tracing",
  "tracing-core",
  "tracing-log",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,12 +9,27 @@ repository = "https://github.com/WasmEdge/wasmedgeup"
 license = "Apache-2.0"
 
 [dependencies]
+cfg-if = "1.0.0"
 clap = { version = "4.5.36", features = ["derive"] }
+dirs = "6.0.0"
 git2 = { version = "0.20.1", features = ["vendored-libgit2"] }
+indicatif = { version = "0.17.11", features = ["tokio"] }
 reqwest = "0.12.15"
 semver = "1.0.26"
 snafu = "0.8.5"
-tokio = { version = "1.44.2", features = ["macros", "rt-multi-thread"] }
+tempfile = "3.19.1"
+tokio = { version = "1.44.2", features = ["fs", "macros", "rt-multi-thread"] }
+tracing = "0.1.41"
+tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
+url = "2.5.4"
+walkdir = "2.5.0"
+
+[target.'cfg(unix)'.dependencies]
+flate2 = "1.1.1"
+tar = "0.4.44"
+
+[target.'cfg(windows)'.dependencies]
+zip = "2.6.1"
 
 [dev-dependencies]
 rstest = "0.25.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ snafu = "0.8.5"
 tempfile = "3.19.1"
 tokio = { version = "1.44.2", features = ["fs", "macros", "rt-multi-thread"] }
 tracing = "0.1.41"
-tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
+tracing-subscriber = "0.3.19"
 url = "2.5.4"
 walkdir = "2.5.0"
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,13 +1,29 @@
-use crate::prelude::*;
+use std::{fmt::Write, path::Path, sync::OnceLock};
+
+use crate::{
+    prelude::*,
+    target::{TargetArch, TargetOS},
+};
 pub mod releases;
+use indicatif::{ProgressBar, ProgressState, ProgressStyle};
 pub use releases::ReleasesFilter;
 
-use semver::Version;
+use reqwest::Response;
+use semver::{Comparator, Prerelease, Version, VersionReq};
+use snafu::ResultExt;
+use tempfile::NamedTempFile;
+use tokio::{
+    fs::{File, OpenOptions},
+    io::AsyncWriteExt,
+};
+use url::Url;
 
 #[derive(Debug, Clone, Default)]
 pub struct WasmEdgeApiClient {}
 
 const WASM_EDGE_GIT_URL: &str = "https://github.com/WasmEdge/WasmEdge.git";
+const WASM_EDGE_RELEASE_ASSET_BASE_URL: &str =
+    "https://github.com/WasmEdge/WasmEdge/releases/download";
 
 impl WasmEdgeApiClient {
     pub fn releases(&self, filter: ReleasesFilter, num_releases: usize) -> Result<Vec<Version>> {
@@ -19,4 +35,166 @@ impl WasmEdgeApiClient {
         let releases = releases::get_all(WASM_EDGE_GIT_URL, ReleasesFilter::Stable)?;
         releases.into_iter().next().ok_or(Error::Unknown)
     }
+
+    pub async fn download_asset(
+        &self,
+        asset: &Asset,
+        tmpdir: impl AsRef<Path>,
+        no_progress: bool,
+    ) -> Result<NamedTempFile> {
+        let url = asset.url()?;
+        tracing::debug!(%url, "Starting download for asset");
+
+        let response = reqwest::get(url).await.context(RequestSnafu {
+            resource: "asset download",
+        })?;
+
+        let named = NamedTempFile::new_in(tmpdir)?;
+        let mut async_file = OpenOptions::new().write(true).open(named.path()).await?;
+
+        download_asset(no_progress, response, &mut async_file).await?;
+        drop(async_file);
+
+        Ok(named)
+    }
+}
+
+#[tracing::instrument(level = tracing::Level::DEBUG, skip(response, target_file), fields(size = response.content_length()))]
+async fn download_asset(
+    no_progress: bool,
+    mut response: Response,
+    target_file: &mut File,
+) -> Result<()> {
+    let content_length = response.content_length().unwrap_or(0);
+
+    let pb = if !no_progress && content_length > 0 {
+        Some(download_progress_bar(
+            response.content_length().unwrap_or_default(),
+        ))
+    } else {
+        None
+    };
+
+    while let Some(mut chunk) = response
+        .chunk()
+        .await
+        .context(RequestSnafu { resource: "chunk" })?
+    {
+        if let Some(ref pb) = pb {
+            pb.inc(chunk.len() as u64)
+        }
+        target_file.write_buf(&mut chunk).await?;
+    }
+
+    target_file.flush().await?;
+
+    if let Some(ref pb) = pb {
+        pb.finish_and_clear();
+    }
+
+    Ok(())
+}
+
+#[derive(Debug, Clone)]
+pub struct Asset {
+    pub version: Version,
+    pub archive_name: String,
+    pub install_name: String,
+}
+
+impl Asset {
+    pub fn new(version: &Version, os: &TargetOS, arch: &TargetArch) -> Self {
+        Self {
+            version: version.clone(),
+            archive_name: Self::format_archive_name(version, os, arch),
+            install_name: Self::format_install_name(version, os),
+        }
+    }
+
+    pub fn url(&self) -> Result<Url> {
+        let mut url = Url::parse(WASM_EDGE_RELEASE_ASSET_BASE_URL)
+            .expect("WASM_EDGE_RELEASE_ASSET_BASE_URL must be a valid URL");
+
+        url.path_segments_mut()
+            .expect("base is valid URL")
+            .extend(&[&self.version.to_string(), &self.archive_name]);
+
+        Ok(url)
+    }
+
+    fn format_archive_name(version: &Version, os: &TargetOS, arch: &TargetArch) -> String {
+        use TargetArch as Arch;
+        use TargetOS as OS;
+
+        match (os, arch) {
+            (OS::Ubuntu, Arch::X86_64) => {
+                format!("WasmEdge-{}-ubuntu20.04_x86_64.tar.gz", version)
+            }
+            (OS::Ubuntu, Arch::Aarch64) if is_arm_ubuntu_supported(version) => {
+                format!("WasmEdge-{}-ubuntu20.04_aarch64.tar.gz", version)
+            }
+            (OS::Linux | OS::Ubuntu, arch) => {
+                let manylinux_version = if is_manylinux2014_supported(version) {
+                    "manylinux2014"
+                } else {
+                    "manylinux_2_28"
+                };
+                let arch = match arch {
+                    Arch::X86_64 => "x86_64",
+                    Arch::Aarch64 => "aarch64",
+                };
+                format!("WasmEdge-{}-{}_{}.tar.gz", version, manylinux_version, arch)
+            }
+            (OS::Darwin, Arch::X86_64) => {
+                format!("WasmEdge-{}-darwin_x86_64.tar.gz", version)
+            }
+            (OS::Darwin, Arch::Aarch64) => {
+                format!("WasmEdge-{}-darwin_arm64.tar.gz", version)
+            }
+            (OS::Windows, _) => {
+                format!("WasmEdge-{}-windows.zip", version)
+            }
+        }
+    }
+
+    fn format_install_name(version: &Version, os: &TargetOS) -> String {
+        use TargetOS as OS;
+
+        match os {
+            OS::Linux | OS::Ubuntu => format!("WasmEdge-{}-Linux", version),
+            OS::Darwin => format!("WasmEdge-{}-Darwin", version),
+            OS::Windows => format!("WasmEdge-{}-Windows", version),
+        }
+    }
+}
+
+static MANYLINUX2014_SUPPORTED_VERSIONS: OnceLock<VersionReq> = OnceLock::new();
+
+fn is_manylinux2014_supported(version: &Version) -> bool {
+    let req = MANYLINUX2014_SUPPORTED_VERSIONS.get_or_init(|| VersionReq {
+        comparators: vec![Comparator {
+            op: semver::Op::LessEq,
+            major: 0,
+            minor: Some(14),
+            patch: None,
+            pre: Prerelease::EMPTY,
+        }],
+    });
+
+    req.matches(version)
+}
+
+fn is_arm_ubuntu_supported(version: &Version) -> bool {
+    // ARM-based Ubuntu 20.04 is supported after 0.13.5
+    version >= &Version::new(0, 13, 5)
+}
+
+fn download_progress_bar(size: u64) -> ProgressBar {
+    let pb = ProgressBar::new(size);
+    pb.set_style(ProgressStyle::with_template("{spinner:.green} [{elapsed_precise}] [{wide_bar:.cyan/blue}] {bytes}/{total_bytes} ({eta})")
+        .unwrap()
+        .with_key("eta", |state: &ProgressState, w: &mut dyn Write| write!(w, "{:.1}s", state.eta().as_secs_f64()).unwrap())
+        .progress_chars("#>-"));
+
+    pb
 }

--- a/src/bin/wasmedgeup.rs
+++ b/src/bin/wasmedgeup.rs
@@ -1,18 +1,28 @@
 use clap::Parser;
+use tracing::Level;
 use wasmedgeup::cli::Cli;
 use wasmedgeup::cli::CommandExecutor;
 use wasmedgeup::prelude::*;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    tracing_subscriber::fmt::init();
-
     let cli = Cli::parse();
     let ctx = cli.context(Default::default());
+
+    init_tracing(cli.verbose);
 
     if let Some(command) = cli.commands {
         command.execute(ctx).await?;
     };
 
     Ok(())
+}
+
+fn init_tracing(verbosity: u8) {
+    let level = match verbosity {
+        0 => Level::INFO,
+        1 => Level::DEBUG,
+        2.. => Level::TRACE,
+    };
+    tracing_subscriber::fmt().with_max_level(level).init();
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -38,6 +38,16 @@ pub struct Cli {
 #[derive(Debug, Clone, Default)]
 pub struct CommandContext {
     pub client: WasmEdgeApiClient,
+    pub no_progress: bool,
+}
+
+impl Cli {
+    pub fn context(&self, client: WasmEdgeApiClient) -> CommandContext {
+        CommandContext {
+            client,
+            no_progress: self.quiet,
+        }
+    }
 }
 
 pub trait CommandExecutor {
@@ -63,6 +73,7 @@ impl CommandExecutor for Commands {
 
         match self {
             List(args) => args.execute(ctx).await,
+            Install(args) => args.execute(ctx).await,
             _ => todo!(),
         }
     }

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -1,8 +1,35 @@
-use std::path::PathBuf;
+use std::{
+    fmt::Write,
+    path::{Path, PathBuf},
+    sync::OnceLock,
+};
 
 use clap::Parser;
+use indicatif::{ProgressBar, ProgressState, ProgressStyle};
+use reqwest::Response;
+use semver::{Comparator, Prerelease, Version, VersionReq};
+use snafu::ResultExt;
+use tokio::{fs::File, io::AsyncWriteExt};
+use tracing::Instrument;
+use url::Url;
 
-use crate::target::{TargetArch, TargetOS};
+use crate::{
+    cli::{CommandContext, CommandExecutor},
+    prelude::*,
+    target::{TargetArch, TargetOS},
+};
+
+const WASM_EDGE_RELEASE_ASSET_BASE_URL: &str =
+    "https://github.com/WasmEdge/WasmEdge/releases/download/";
+
+fn default_path() -> PathBuf {
+    let home_dir = dirs::home_dir().expect("home_dir should be present");
+    home_dir.join(".wasmedge")
+}
+
+fn default_tmpdir() -> PathBuf {
+    std::env::temp_dir()
+}
 
 #[derive(Debug, Parser)]
 pub struct InstallArgs {
@@ -17,7 +44,7 @@ pub struct InstallArgs {
 
     /// Set the temporary directory for staging downloaded assets
     ///
-    /// Defaults to `/tmp` on Unix-like systems and `%LOCALAPPDATA%\Temp` on Windows.
+    /// Defaults to the system temporary directory, this differs between operating systems.
     #[arg(short, long)]
     pub tmpdir: Option<PathBuf>,
 
@@ -32,4 +59,204 @@ pub struct InstallArgs {
     /// `wasmedgeup` will detect the architecture of your host system by default.
     #[arg(short, long)]
     pub arch: Option<TargetArch>,
+}
+
+impl CommandExecutor for InstallArgs {
+    async fn execute(mut self, ctx: CommandContext) -> Result<()> {
+        let version = match self.version.as_str() {
+            "latest" => ctx.client.latest_release()?,
+            v => Version::parse(v).context(SemVerSnafu {})?,
+        };
+
+        let os = self.os.get_or_insert_default();
+        let arch = self.arch.get_or_insert_default();
+        tracing::debug!(?os, ?arch, "Host OS and architecture detected");
+        let asset = Asset::new(&version, os, arch);
+
+        let mut response = self
+            .fetch_release_asset(&version, &asset.archive_name)
+            .await?;
+
+        let tmpdir = self.tmpdir.unwrap_or_else(default_tmpdir);
+        let tmpfile = tempfile::tempfile_in(&tmpdir).unwrap();
+        let mut file = File::from_std(tmpfile.try_clone()?);
+
+        let pb = if ctx.no_progress {
+            None
+        } else {
+            Some(download_progress_bar(
+                response.content_length().unwrap_or_default(),
+            ))
+        };
+
+        while let Some(mut chunk) = response
+            .chunk()
+            .await
+            .context(RequestSnafu { resource: "chunk" })?
+        {
+            if let Some(ref pb) = pb {
+                pb.inc(chunk.len() as u64)
+            }
+            file.write_buf(&mut chunk).await?;
+        }
+
+        file.flush().await?;
+        if let Some(ref pb) = pb {
+            pb.finish_and_clear()
+        }
+
+        tracing::debug!(dest = %tmpdir.display(), "Start unpacking");
+        Self::extract_asset_archive(tmpfile.try_clone()?, &tmpdir).await?;
+
+        // Try with `tmpdir/WasmEdge-{version}-{os}` first, and if it's not a directory, fallback
+        // to `tmpdir`
+        // (both patterns are used in WasmEdge)
+        let mut extracted_dir = tmpdir.join(&asset.install_name);
+        if !extracted_dir.is_dir() {
+            extracted_dir = tmpdir;
+        }
+
+        let target_dir = self.path.unwrap_or_else(default_path);
+        tracing::debug!(extracted_dir = %extracted_dir.display(), target_dir = %target_dir.display(), "Start copying files to target location");
+
+        crate::fs::copy_tree(&extracted_dir, &target_dir).await;
+
+        Ok(())
+    }
+}
+
+impl InstallArgs {
+    async fn fetch_release_asset(
+        &mut self,
+        version: &Version,
+        archive_name: &str,
+    ) -> Result<Response> {
+        // This should never fail
+        let url = Url::parse(WASM_EDGE_RELEASE_ASSET_BASE_URL).unwrap();
+        let url = url.join(&format!("{}/", version)).context(UrlSnafu {})?;
+
+        let url = url.join(archive_name).context(UrlSnafu {})?;
+
+        let span = tracing::debug_span!("sending_request", %url);
+
+        let response = reqwest::get(url)
+            .instrument(span)
+            .await
+            .context(RequestSnafu { resource: "assets" })?;
+
+        Ok(response)
+    }
+
+    async fn extract_asset_archive(mut file: std::fs::File, dest: &Path) -> Result<()> {
+        use std::io::Seek;
+        use tokio::fs;
+
+        file.rewind()?;
+        fs::create_dir_all(dest).await?;
+        Self::extract_to(file, dest)?;
+
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    fn extract_to(file: std::fs::File, to: &Path) -> Result<()> {
+        use flate2::read::GzDecoder;
+        use tar::Archive;
+
+        let tar = GzDecoder::new(file);
+        let mut archive = Archive::new(tar);
+        archive.unpack(to).context(ExtractSnafu {})?;
+
+        Ok(())
+    }
+
+    #[cfg(windows)]
+    fn extract_to(file: std::fs::File, to: &Path) -> Result<()> {
+        use zip::ZipArchive;
+
+        let mut archive = Archive::new(file).context(ExtractSnafu {})?;
+        archive.extract(path).context(ExtractSnafu {})?;
+
+        Ok(())
+    }
+}
+
+fn download_progress_bar(size: u64) -> ProgressBar {
+    let pb = ProgressBar::new(size);
+    pb.set_style(ProgressStyle::with_template("{spinner:.green} [{elapsed_precise}] [{wide_bar:.cyan/blue}] {bytes}/{total_bytes} ({eta})")
+        .unwrap()
+        .with_key("eta", |state: &ProgressState, w: &mut dyn Write| write!(w, "{:.1}s", state.eta().as_secs_f64()).unwrap())
+        .progress_chars("#>-"));
+
+    pb
+}
+
+static MANYLINUX2014_SUPPORTED_VERSIONS: OnceLock<VersionReq> = OnceLock::new();
+
+fn is_manylinux2014_supported(version: &Version) -> bool {
+    let req = MANYLINUX2014_SUPPORTED_VERSIONS.get_or_init(|| VersionReq {
+        comparators: vec![Comparator {
+            op: semver::Op::LessEq,
+            major: 0,
+            minor: Some(14),
+            patch: None,
+            pre: Prerelease::EMPTY,
+        }],
+    });
+
+    req.matches(version)
+}
+
+struct Asset {
+    install_name: String,
+    archive_name: String,
+}
+
+impl Asset {
+    fn new(version: &Version, os: &TargetOS, arch: &TargetArch) -> Self {
+        use TargetArch as Arch;
+        use TargetOS as OS;
+
+        let archive_name = match (os, arch) {
+            (OS::Ubuntu, Arch::X86_64) => {
+                format!("WasmEdge-{}-ubuntu20.04_x86_64.tar.gz", version)
+            }
+            // ARM-based Ubuntu 20.04 is supported after 0.13.5
+            (OS::Ubuntu, Arch::Aarch64) if version >= &Version::new(0, 13, 5) => {
+                format!("WasmEdge-{}-ubuntu20.04_aarch64.tar.gz", version)
+            }
+            (OS::Linux | OS::Ubuntu, arch) => {
+                let manylinux_version = if is_manylinux2014_supported(version) {
+                    "manylinux2014"
+                } else {
+                    "manylinux_2_28"
+                };
+                let arch = match arch {
+                    Arch::X86_64 => "x86_64",
+                    Arch::Aarch64 => "aarch64",
+                };
+                format!("WasmEdge-{}-{}_{}.tar.gz", version, manylinux_version, arch)
+            }
+            (OS::Darwin, Arch::X86_64) => {
+                format!("WasmEdge-{}-darwin_x86_64.tar.gz", version)
+            }
+            (OS::Darwin, Arch::Aarch64) => {
+                format!("WasmEdge-{}-darwin_arm64.tar.gz", version)
+            }
+            (OS::Windows, _) => {
+                format!("WasmEdge-{}-windows.zip", version)
+            }
+        };
+
+        let install_name = match os {
+            OS::Linux | OS::Ubuntu => format!("WasmEdge-{}-Linux", version),
+            OS::Darwin => format!("WasmEdge-{}-Darwin", version),
+            OS::Windows => format!("WasmEdge-{}-Windows", version),
+        };
+
+        Self {
+            archive_name,
+            install_name,
+        }
+    }
 }

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -1,26 +1,15 @@
-use std::{
-    fmt::Write,
-    path::{Path, PathBuf},
-    sync::OnceLock,
-};
+use std::path::PathBuf;
 
 use clap::Parser;
-use indicatif::{ProgressBar, ProgressState, ProgressStyle};
-use reqwest::Response;
-use semver::{Comparator, Prerelease, Version, VersionReq};
+use semver::Version;
 use snafu::ResultExt;
-use tokio::{fs::File, io::AsyncWriteExt};
-use tracing::Instrument;
-use url::Url;
 
 use crate::{
+    api::{Asset, WasmEdgeApiClient},
     cli::{CommandContext, CommandExecutor},
     prelude::*,
     target::{TargetArch, TargetOS},
 };
-
-const WASM_EDGE_RELEASE_ASSET_BASE_URL: &str =
-    "https://github.com/WasmEdge/WasmEdge/releases/download/";
 
 fn default_path() -> PathBuf {
     let home_dir = dirs::home_dir().expect("home_dir should be present");
@@ -62,201 +51,72 @@ pub struct InstallArgs {
 }
 
 impl CommandExecutor for InstallArgs {
+    /// Executes the installation process by resolving the version, downloading the asset,
+    /// unpacking it, and copying the extracted files to the target directory.
+    ///
+    /// # Steps:
+    /// 1. Resolves the version (either a specific version or the latest).
+    /// 2. Downloads the asset for the appropriate OS and architecture.
+    /// 3. Unpacks the asset to a temporary directory.
+    /// 4. Copies the extracted files to the target directory.
+    ///
+    /// # Arguments
+    ///
+    /// * `ctx` - The command context containing the client and progress bar settings.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if any step fails, such as download failure, extraction issues,
+    /// or copying issues.
+    #[tracing::instrument(name = "install", skip_all, fields(version = self.version))]
     async fn execute(mut self, ctx: CommandContext) -> Result<()> {
-        let version = match self.version.as_str() {
-            "latest" => ctx.client.latest_release()?,
-            v => Version::parse(v).context(SemVerSnafu {})?,
-        };
+        let version = self.resolve_version(&ctx.client).inspect_err(
+            |e| tracing::error!(error = %e.to_string(), "Failed to resolve version"),
+        )?;
+        tracing::debug!(%version, "Resolved version for installation");
 
         let os = self.os.get_or_insert_default();
         let arch = self.arch.get_or_insert_default();
         tracing::debug!(?os, ?arch, "Host OS and architecture detected");
+
         let asset = Asset::new(&version, os, arch);
-
-        let mut response = self
-            .fetch_release_asset(&version, &asset.archive_name)
-            .await?;
-
         let tmpdir = self.tmpdir.unwrap_or_else(default_tmpdir);
-        let tmpfile = tempfile::tempfile_in(&tmpdir).unwrap();
-        let mut file = File::from_std(tmpfile.try_clone()?);
-
-        let pb = if ctx.no_progress {
-            None
-        } else {
-            Some(download_progress_bar(
-                response.content_length().unwrap_or_default(),
-            ))
-        };
-
-        while let Some(mut chunk) = response
-            .chunk()
+        let file = ctx
+            .client
+            .download_asset(&asset, &tmpdir, ctx.no_progress)
             .await
-            .context(RequestSnafu { resource: "chunk" })?
-        {
-            if let Some(ref pb) = pb {
-                pb.inc(chunk.len() as u64)
-            }
-            file.write_buf(&mut chunk).await?;
-        }
+            .inspect_err(|e| tracing::error!(error = %e.to_string(), "Failed to download asset"))?;
 
-        file.flush().await?;
-        if let Some(ref pb) = pb {
-            pb.finish_and_clear()
-        }
-
-        tracing::debug!(dest = %tmpdir.display(), "Start unpacking");
-        Self::extract_asset_archive(tmpfile.try_clone()?, &tmpdir).await?;
+        tracing::debug!(file_path = %file.path().display(), dest = %tmpdir.display(), "Starting extraction of asset");
+        crate::fs::extract_archive(file.into_file(), &tmpdir)
+            .await
+            .inspect_err(|e| tracing::error!(error = %e.to_string(), "Failed to extract asset"))?;
+        tracing::debug!(dest = %tmpdir.display(), "Extraction completed successfully");
 
         // Try with `tmpdir/WasmEdge-{version}-{os}` first, and if it's not a directory, fallback
         // to `tmpdir`
         // (both patterns are used in WasmEdge)
         let mut extracted_dir = tmpdir.join(&asset.install_name);
         if !extracted_dir.is_dir() {
+            tracing::debug!(extracted_dir = %extracted_dir.display(), "Falling back to tmpdir as extracted directory");
             extracted_dir = tmpdir;
         }
 
         let target_dir = self.path.unwrap_or_else(default_path);
         tracing::debug!(extracted_dir = %extracted_dir.display(), target_dir = %target_dir.display(), "Start copying files to target location");
-
         crate::fs::copy_tree(&extracted_dir, &target_dir).await;
+        tracing::debug!(target_dir = %target_dir.display(), "Copying files to target location completed");
 
         Ok(())
     }
 }
 
 impl InstallArgs {
-    async fn fetch_release_asset(
-        &mut self,
-        version: &Version,
-        archive_name: &str,
-    ) -> Result<Response> {
-        // This should never fail
-        let url = Url::parse(WASM_EDGE_RELEASE_ASSET_BASE_URL).unwrap();
-        let url = url.join(&format!("{}/", version)).context(UrlSnafu {})?;
-
-        let url = url.join(archive_name).context(UrlSnafu {})?;
-
-        let span = tracing::debug_span!("sending_request", %url);
-
-        let response = reqwest::get(url)
-            .instrument(span)
-            .await
-            .context(RequestSnafu { resource: "assets" })?;
-
-        Ok(response)
-    }
-
-    async fn extract_asset_archive(mut file: std::fs::File, dest: &Path) -> Result<()> {
-        use std::io::Seek;
-        use tokio::fs;
-
-        file.rewind()?;
-        fs::create_dir_all(dest).await?;
-        Self::extract_to(file, dest)?;
-
-        Ok(())
-    }
-
-    #[cfg(unix)]
-    fn extract_to(file: std::fs::File, to: &Path) -> Result<()> {
-        use flate2::read::GzDecoder;
-        use tar::Archive;
-
-        let tar = GzDecoder::new(file);
-        let mut archive = Archive::new(tar);
-        archive.unpack(to).context(ExtractSnafu {})?;
-
-        Ok(())
-    }
-
-    #[cfg(windows)]
-    fn extract_to(file: std::fs::File, to: &Path) -> Result<()> {
-        use zip::ZipArchive;
-
-        let mut archive = ZipArchive::new(file).context(ExtractSnafu {})?;
-        archive.extract(to).context(ExtractSnafu {})?;
-
-        Ok(())
-    }
-}
-
-fn download_progress_bar(size: u64) -> ProgressBar {
-    let pb = ProgressBar::new(size);
-    pb.set_style(ProgressStyle::with_template("{spinner:.green} [{elapsed_precise}] [{wide_bar:.cyan/blue}] {bytes}/{total_bytes} ({eta})")
-        .unwrap()
-        .with_key("eta", |state: &ProgressState, w: &mut dyn Write| write!(w, "{:.1}s", state.eta().as_secs_f64()).unwrap())
-        .progress_chars("#>-"));
-
-    pb
-}
-
-static MANYLINUX2014_SUPPORTED_VERSIONS: OnceLock<VersionReq> = OnceLock::new();
-
-fn is_manylinux2014_supported(version: &Version) -> bool {
-    let req = MANYLINUX2014_SUPPORTED_VERSIONS.get_or_init(|| VersionReq {
-        comparators: vec![Comparator {
-            op: semver::Op::LessEq,
-            major: 0,
-            minor: Some(14),
-            patch: None,
-            pre: Prerelease::EMPTY,
-        }],
-    });
-
-    req.matches(version)
-}
-
-struct Asset {
-    install_name: String,
-    archive_name: String,
-}
-
-impl Asset {
-    fn new(version: &Version, os: &TargetOS, arch: &TargetArch) -> Self {
-        use TargetArch as Arch;
-        use TargetOS as OS;
-
-        let archive_name = match (os, arch) {
-            (OS::Ubuntu, Arch::X86_64) => {
-                format!("WasmEdge-{}-ubuntu20.04_x86_64.tar.gz", version)
-            }
-            // ARM-based Ubuntu 20.04 is supported after 0.13.5
-            (OS::Ubuntu, Arch::Aarch64) if version >= &Version::new(0, 13, 5) => {
-                format!("WasmEdge-{}-ubuntu20.04_aarch64.tar.gz", version)
-            }
-            (OS::Linux | OS::Ubuntu, arch) => {
-                let manylinux_version = if is_manylinux2014_supported(version) {
-                    "manylinux2014"
-                } else {
-                    "manylinux_2_28"
-                };
-                let arch = match arch {
-                    Arch::X86_64 => "x86_64",
-                    Arch::Aarch64 => "aarch64",
-                };
-                format!("WasmEdge-{}-{}_{}.tar.gz", version, manylinux_version, arch)
-            }
-            (OS::Darwin, Arch::X86_64) => {
-                format!("WasmEdge-{}-darwin_x86_64.tar.gz", version)
-            }
-            (OS::Darwin, Arch::Aarch64) => {
-                format!("WasmEdge-{}-darwin_arm64.tar.gz", version)
-            }
-            (OS::Windows, _) => {
-                format!("WasmEdge-{}-windows.zip", version)
-            }
-        };
-
-        let install_name = match os {
-            OS::Linux | OS::Ubuntu => format!("WasmEdge-{}-Linux", version),
-            OS::Darwin => format!("WasmEdge-{}-Darwin", version),
-            OS::Windows => format!("WasmEdge-{}-Windows", version),
-        };
-
-        Self {
-            archive_name,
-            install_name,
+    fn resolve_version(&self, client: &WasmEdgeApiClient) -> Result<Version> {
+        if self.version == "latest" {
+            client.latest_release()
+        } else {
+            Version::parse(&self.version).context(SemVerSnafu {})
         }
     }
 }

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -174,8 +174,8 @@ impl InstallArgs {
     fn extract_to(file: std::fs::File, to: &Path) -> Result<()> {
         use zip::ZipArchive;
 
-        let mut archive = Archive::new(file).context(ExtractSnafu {})?;
-        archive.extract(path).context(ExtractSnafu {})?;
+        let mut archive = ZipArchive::new(file).context(ExtractSnafu {})?;
+        archive.extract(to).context(ExtractSnafu {})?;
 
         Ok(())
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -12,6 +12,27 @@ pub enum Error {
     #[snafu(display("Invalid semantic version specifier"))]
     SemVer { source: semver::Error },
 
+    #[snafu(display("Error constructing release URL"))]
+    Url { source: url::ParseError },
+
+    #[snafu(display("Unable to request resource '{}'", resource))]
+    Request {
+        source: reqwest::Error,
+        resource: &'static str,
+    },
+
+    #[snafu(display("Unable to extract archive"))]
+    Extract {
+        #[cfg(unix)]
+        source: std::io::Error,
+
+        #[cfg(windows)]
+        source: zip::ZipError,
+    },
+
+    #[snafu(transparent)]
+    IO { source: std::io::Error },
+
     #[default]
     #[snafu(display("Unknown error occurred"))]
     Unknown,

--- a/src/error.rs
+++ b/src/error.rs
@@ -27,7 +27,7 @@ pub enum Error {
         source: std::io::Error,
 
         #[cfg(windows)]
-        source: zip::ZipError,
+        source: zip::result::ZipError,
     },
 
     #[snafu(transparent)]

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -1,0 +1,51 @@
+use std::path::{Path, PathBuf};
+
+use tokio::fs;
+use walkdir::WalkDir;
+
+pub async fn copy_tree(from_dir: &Path, to_dir: &Path) {
+    let num_components = from_dir.components().count();
+
+    for entry in WalkDir::new(from_dir).into_iter().filter_map(|e| e.ok()) {
+        tracing::trace!(entry = %entry.path().display(), "Copying entry");
+        let Ok(metadata) = entry.metadata() else {
+            continue;
+        };
+        if !metadata.is_file() {
+            continue;
+        }
+
+        // Calculate the target location based on from_dir, to_dir, and entry
+        // by first calculate the path of entry relative to from_dir, and then append it to to_dir
+        //
+        // # Example
+        // from_dir = '/from/path
+        // entry = '/from/path/foo/bar/something.txt'
+        // to_dir = '/to/path'
+        // => num_components = 3 ([RootDir, "from", "path"])
+        // => chained = [RootDir, "to", "path"].chain(["foo", "bar", "something.txt"])
+        // => target_loc = "/to/path/foo/bar/something.txt"
+        let target_loc = to_dir
+            .components()
+            .chain(entry.path().components().skip(num_components))
+            .collect::<PathBuf>();
+
+        let Some(parent) = target_loc.parent() else {
+            tracing::warn!(location = %target_loc.display(), "Missing parent for target location");
+            continue;
+        };
+        if let Err(e) = fs::create_dir_all(parent).await {
+            tracing::warn!(error = %e, directories = %parent.display(), "Failed to create directories");
+            continue;
+        };
+
+        if let Err(e) = fs::copy(entry.path(), &target_loc).await {
+            tracing::warn!(
+                error = %e,
+                entry = %entry.path().display(),
+                target_loc = %target_loc.display(),
+                "Failed to copy file to target location",
+            );
+        };
+    }
+}

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -1,3 +1,6 @@
+use crate::prelude::*;
+use snafu::ResultExt;
+
 use std::path::{Path, PathBuf};
 
 use tokio::fs;
@@ -48,4 +51,64 @@ pub async fn copy_tree(from_dir: &Path, to_dir: &Path) {
             );
         };
     }
+}
+
+/// Extracts the contents of a compressed archive (`.tar.gz` for Unix-like systems, `.zip` for Windows) to a specified directory.
+///
+/// # Arguments
+///
+/// * `file` - A file object representing the compressed archive. This file must be opened in read mode.
+/// * `dest` - The destination directory to which the contents will be extracted.
+///
+/// # Errors
+///
+/// Returns an error if the extraction fails. This could happen if the archive format is unsupported or
+/// if the destination path cannot be created.
+///
+/// # Example
+/// ```rust
+/// let file = std::fs::File::open("archive.tar.gz")?;
+/// let dest = Path::new("/path/to/destination");
+/// extract_archive(file, dest).await?;
+/// ```
+pub async fn extract_archive(mut file: std::fs::File, dest: &Path) -> Result<()> {
+    use std::io::Seek;
+    use tokio::fs;
+
+    fs::create_dir_all(dest).await.inspect_err(
+        |e| tracing::error!(error = %e.to_string(), "Failed to create directory during extraction"),
+    )?;
+    file.rewind()?;
+
+    #[cfg(unix)]
+    {
+        use flate2::read::GzDecoder;
+        let decompressed = GzDecoder::new(file);
+        extract_tar(decompressed, dest)?;
+    }
+
+    #[cfg(windows)]
+    extract_zip(file, dest)?;
+
+    Ok(())
+}
+
+#[cfg(unix)]
+fn extract_tar(file: impl std::io::Read, to: &Path) -> Result<()> {
+    use tar::Archive;
+
+    let mut archive = Archive::new(file);
+    archive.unpack(to).context(ExtractSnafu {})?;
+
+    Ok(())
+}
+
+#[cfg(windows)]
+fn extract_zip(file: std::fs::File, to: &Path) -> Result<()> {
+    use zip::ZipArchive;
+
+    let mut archive = ZipArchive::new(file).context(ExtractSnafu {})?;
+    archive.extract(to).context(ExtractSnafu {})?;
+
+    Ok(())
 }

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -64,13 +64,6 @@ pub async fn copy_tree(from_dir: &Path, to_dir: &Path) {
 ///
 /// Returns an error if the extraction fails. This could happen if the archive format is unsupported or
 /// if the destination path cannot be created.
-///
-/// # Example
-/// ```rust
-/// let file = std::fs::File::open("archive.tar.gz")?;
-/// let dest = Path::new("/path/to/destination");
-/// extract_archive(file, dest).await?;
-/// ```
 pub async fn extract_archive(mut file: std::fs::File, dest: &Path) -> Result<()> {
     use std::io::Seek;
     use tokio::fs;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,5 +2,6 @@ pub mod api;
 pub mod cli;
 pub mod commands;
 pub mod error;
+pub mod fs;
 pub mod prelude;
 mod target;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,14 @@
 use clap::Parser;
 use wasmedgeup::cli::Cli;
-use wasmedgeup::cli::CommandContext;
 use wasmedgeup::cli::CommandExecutor;
 use wasmedgeup::prelude::*;
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    tracing_subscriber::fmt::init();
+
     let cli = Cli::parse();
-    let ctx = CommandContext::default();
+    let ctx = cli.context(Default::default());
 
     if let Some(command) = cli.commands {
         command.execute(ctx).await?;

--- a/src/target.rs
+++ b/src/target.rs
@@ -4,15 +4,88 @@ use clap::ValueEnum;
 pub enum TargetOS {
     Linux,
     Ubuntu,
-    #[value(alias = "macos")]
+    /// aliases: [darwin, macos]
+    #[value(alias("macos"))]
     Darwin,
     Windows,
 }
 
+impl Default for TargetOS {
+    fn default() -> Self {
+        cfg_if::cfg_if! {
+            if #[cfg(target_os = "linux")] {
+                match get_ubuntu_version() {
+                    Some((20, minor)) if minor >= 4 => Self::Ubuntu,
+                    Some((major, _)) if major > 20 => Self::Ubuntu,
+                    _ => Self::Linux
+                }
+            } else if #[cfg(target_os = "macos")] {
+                Self::Darwin
+            } else if #[cfg(target_os = "windows")] {
+                Self::Windows
+            } else {
+                compile_error!("Unsupported target OS: '{}'", std::env::consts::OS);
+            }
+        }
+    }
+}
+
+macro_rules! unwrap_or_continue {
+    ($expr:expr, $variant:ident) => {
+        match $expr {
+            $variant(v) => v,
+            _ => continue,
+        }
+    };
+}
+
+#[cfg(target_os = "linux")]
+fn get_ubuntu_version() -> Option<(u32, u32)> {
+    use std::fs;
+
+    let Ok(lsb_release) = fs::read_to_string("/etc/lsb-release") else {
+        return None;
+    };
+
+    for line in lsb_release.lines() {
+        let (key, value) = unwrap_or_continue!(line.split_once('='), Some);
+
+        if key.eq_ignore_ascii_case("RELEASE") {
+            let (major, minor) = unwrap_or_continue!(value.split_once('.'), Some);
+            let major = unwrap_or_continue!(major.parse(), Ok);
+            let minor = unwrap_or_continue!(minor.parse(), Ok);
+            return Some((major, minor));
+        }
+
+        if key.eq_ignore_ascii_case("DESCRIPTION") && value.contains("Ubuntu 20.04") {
+            return Some((20, 4));
+        }
+    }
+
+    None
+}
+
 #[derive(Debug, Clone, ValueEnum)]
 pub enum TargetArch {
-    #[value(name = "x84_64", alias("x64"))]
-    X84_64,
-    #[value(alias("amd64"))]
+    /// aliases: [x86_64, amd64]
+    #[value(name = "x86_64", alias("amd64"))]
+    X86_64,
+
+    /// aliases: [aarch64, arm64]
+    #[value(alias("arm64"))]
     Aarch64,
+}
+
+impl Default for TargetArch {
+    fn default() -> Self {
+        cfg_if::cfg_if! {
+            if #[cfg(target_arch = "x86_64")] {
+                Self::X86_64
+            } else if #[cfg(target_arch = "aarch64")] {
+                Self::Aarch64
+            } else {
+                compile_error!("Unsupported target architecture: {}", std::env::consts::ARCH);
+            }
+        }
+    }
 }

--- a/tests/install_test.rs
+++ b/tests/install_test.rs
@@ -1,0 +1,59 @@
+use std::path::PathBuf;
+
+use tempfile::{tempdir, TempDir};
+use wasmedgeup::{
+    api::{releases, ReleasesFilter, WasmEdgeApiClient},
+    cli::{CommandContext, CommandExecutor},
+    commands::install::InstallArgs,
+};
+
+const WASM_EDGE_GIT_URL: &str = "https://github.com/WasmEdge/WasmEdge.git";
+
+async fn execute_install_test(version: String, install_dir: PathBuf, tmpdir: TempDir) {
+    let args = InstallArgs {
+        version,
+        path: Some(install_dir.clone()),
+        tmpdir: Some(tmpdir.path().to_path_buf()),
+        os: None,
+        arch: None,
+    };
+
+    let client = WasmEdgeApiClient::default();
+    let ctx = CommandContext {
+        client,
+        no_progress: false,
+    };
+
+    args.execute(ctx).await.expect("install failed");
+
+    assert!(install_dir.exists());
+    assert!(install_dir.read_dir().unwrap().next().is_some());
+
+    #[cfg(unix)]
+    assert!(install_dir.join("bin/wasmedge").exists());
+
+    #[cfg(windows)]
+    assert!(install_dir.join("bin/wasmedge.exe").exists());
+}
+
+#[tokio::test]
+async fn test_install_latest_version() {
+    let tmpdir = tempdir().unwrap();
+    let install_dir = tmpdir.path().join("install_target");
+
+    let all_releases = releases::get_all(WASM_EDGE_GIT_URL, ReleasesFilter::Stable).unwrap();
+    assert!(!all_releases.is_empty());
+
+    execute_install_test(all_releases[0].to_string(), install_dir, tmpdir).await;
+}
+
+#[tokio::test]
+async fn test_install_prerelease_version() {
+    let tmpdir = tempdir().unwrap();
+    let install_dir = tmpdir.path().join("install_target");
+
+    let all_releases = releases::get_all(WASM_EDGE_GIT_URL, ReleasesFilter::All).unwrap();
+    assert!(!all_releases.is_empty());
+
+    execute_install_test(all_releases[0].to_string(), install_dir, tmpdir).await;
+}


### PR DESCRIPTION
## Which GitHub issue does this PR close?

Closes <!-- Add issue number here, e.g., Closes #123 -->

## Why is this needed?

`wasmedgeup` should support the functionality of installing WasmEdge to `--path` or `$HOME/.wasmedgeup`.

## What does this PR change?

Implement the install command.

## How has this been tested?

<!-- Describe the testing process. If no tests were added, explain why (e.g., already covered, not applicable). -->
Manual test, it can download the asset archive, extract the files, and copy them to the specified directory.

## Anything else?

<!-- Include screenshots, documentation updates, or anything else relevant. -->
The `$HOME/.wasmedgeup/env` is not implemented yet, I am thinking splitting it to a separate PR for easier reviewing process.
