### PR TITLE
fix: knope bot commit message

### DIFF
--- a/knope.toml
+++ b/knope.toml
@@ -9,3 +9,4 @@ repo = "wasmedgeup"
 
 [bot.releases]
 enabled = true
+pull_request.title = "chore: release wasmedgeup $version"


### PR DESCRIPTION
## Which GitHub issue does this PR close?

Closes <!-- Add issue number here, e.g., Closes #123 -->

## Why is this needed?

<!-- Briefly explain the motivation behind this change. -->
The default commit message used by the Knope bot for release PRs does not comply with the commitlint rules.

## What does this PR change?

<!-- Summarize the key changes included in this PR. -->
Initially, the commit message was not customizable. After discussing the issue with the Knope team, they released a new version that allows customization. This PR updates our configuration to use the new option so the commit message follows the conventional commits format.

## How has this been tested?

<!-- Describe the testing process. If no tests were added, explain why (e.g., already covered, not applicable). -->
N/A

## Anything else?

<!-- Include screenshots, documentation updates, or anything else relevant. -->
I'm currently using `chore` as the [commit type](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional#type-enum). If another type is preferred, we can change it.