### PR TITLE
ci(audit_check): ensure the permission is enough for triggering the workflow

### DIFF
--- a/.github/workflows/audit_check.yml
+++ b/.github/workflows/audit_check.yml
@@ -3,12 +3,18 @@ name: Security audit
 on:
   push:
     paths:
+      - ".github/workflows/audit_check.yml"
       - "**/Cargo.toml"
       - "**/Cargo.lock"
+  schedule:
+    - cron: '0 0 * * *'
 
 jobs:
   security-audit:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      checks: write
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0


### PR DESCRIPTION
## Which GitHub issue does this PR close?

## Why is this needed?

The previous permissions are incorrect.

## What does this PR change?

Set the correct permissions for the audit checking workflow.

## How has this been tested?

Check the CI.

## Anything else?
