### PR TITLE
feat(install): add checksum verification and install fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -625,6 +625,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2239,10 +2245,12 @@ dependencies = [
  "dirs",
  "flate2",
  "git2",
+ "hex",
  "indicatif",
  "reqwest",
  "rstest",
  "semver",
+ "sha2",
  "snafu",
  "tar",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,8 @@ tracing = "0.1.41"
 tracing-subscriber = "0.3.20"
 url = "2.5.7"
 walkdir = "2.5.0"
+sha2 = "0.10"
+hex = "0.4"
 
 [target.'cfg(unix)'.dependencies]
 flate2 = "1.1.2"

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,4 +1,9 @@
-use std::{fmt::Write, path::Path, sync::OnceLock};
+use std::{
+    fmt::Write,
+    io::{Read, Seek},
+    path::Path,
+    sync::OnceLock,
+};
 
 use crate::{
     prelude::*,
@@ -10,6 +15,7 @@ pub use releases::ReleasesFilter;
 
 use reqwest::Response;
 use semver::{Comparator, Prerelease, Version, VersionReq};
+use sha2::{Digest, Sha256};
 use snafu::ResultExt;
 use tempfile::NamedTempFile;
 use tokio::{
@@ -24,6 +30,8 @@ pub struct WasmEdgeApiClient {}
 const WASM_EDGE_GIT_URL: &str = "https://github.com/WasmEdge/WasmEdge.git";
 const WASM_EDGE_RELEASE_ASSET_BASE_URL: &str =
     "https://github.com/WasmEdge/WasmEdge/releases/download";
+const CHECKSUM_FILE_NAME: &str = "SHA256SUM";
+const BUFFER_SIZE: usize = 8 * 1024; // 8KB
 
 impl WasmEdgeApiClient {
     pub fn releases(&self, filter: ReleasesFilter, num_releases: usize) -> Result<Vec<Version>> {
@@ -56,6 +64,92 @@ impl WasmEdgeApiClient {
         drop(async_file);
 
         Ok(named)
+    }
+
+    pub async fn get_release_checksum(&self, version: &Version, asset: &Asset) -> Result<String> {
+        let mut url = Url::parse(WASM_EDGE_RELEASE_ASSET_BASE_URL)
+            .expect("WASM_EDGE_RELEASE_ASSET_BASE_URL must be a valid URL");
+
+        url.path_segments_mut()
+            .expect("base is valid URL")
+            .extend(&[&version.to_string(), CHECKSUM_FILE_NAME]);
+
+        tracing::debug!(%url, CHECKSUM_FILE_NAME, "Trying checksum file");
+
+        let response = reqwest::get(url).await.context(RequestSnafu {
+            resource: "checksums",
+        })?;
+
+        if !response.status().is_success() {
+            tracing::debug!(
+                status = %response.status(),
+                file = CHECKSUM_FILE_NAME,
+                "Checksum file not found"
+            );
+            return Err(Error::ChecksumNotFound {
+                version: version.to_string(),
+                asset: asset.archive_name.clone(),
+            });
+        }
+
+        let content = response.text().await.context(RequestSnafu {
+            resource: "checksums",
+        })?;
+
+        tracing::debug!(
+            lines = content.lines().count(),
+            file = CHECKSUM_FILE_NAME,
+            "Got checksum file content"
+        );
+
+        for (i, line) in content.lines().enumerate() {
+            tracing::debug!(line_num = i, line = line, "Processing checksum line");
+
+            let parts: Vec<&str> = line.split_whitespace().collect();
+            if parts.len() == 2 {
+                tracing::debug!(checksum = parts[0], file = parts[1], "Found checksum entry");
+
+                if parts[1] == asset.archive_name {
+                    tracing::debug!(checksum = parts[0], "Found matching checksum");
+                    return Ok(parts[0].to_string());
+                }
+            }
+        }
+
+        tracing::error!(
+            version = %version,
+            asset = %asset.archive_name,
+            "No checksum found in any file"
+        );
+
+        Err(Error::ChecksumNotFound {
+            version: version.to_string(),
+            asset: asset.archive_name.clone(),
+        })
+    }
+
+    pub async fn verify_file_checksum(file: &mut std::fs::File, expected: &str) -> Result<()> {
+        let mut hasher = Sha256::new();
+        let mut buffer = vec![0; BUFFER_SIZE];
+
+        loop {
+            let count = file.read(&mut buffer)?;
+            if count == 0 {
+                break;
+            }
+            hasher.update(&buffer[..count]);
+        }
+
+        let actual = hex::encode(hasher.finalize());
+        if actual != expected {
+            return Err(Error::ChecksumMismatch {
+                expected: expected.to_string(),
+                actual,
+            });
+        }
+
+        file.rewind()?;
+        Ok(())
     }
 }
 

--- a/src/bin/wasmedgeup.rs
+++ b/src/bin/wasmedgeup.rs
@@ -12,8 +12,11 @@ async fn main() -> Result<()> {
     init_tracing(cli.verbose);
 
     if let Some(command) = cli.commands {
-        command.execute(ctx).await?;
-    };
+        if let Err(e) = command.execute(ctx).await {
+            eprintln!("{e}");
+            std::process::exit(1);
+        }
+    }
 
     Ok(())
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -33,6 +33,15 @@ pub enum Error {
     #[snafu(transparent)]
     IO { source: std::io::Error },
 
+    #[snafu(display("Error: Cannot {action} at {path}\n\nTo install WasmEdge system-wide:\n  1. Install to {system_dir} (recommended):\n     {sudo}wasmedgeup install {version} -p {system_dir}\n\n  2. Install to user directory (default: $HOME/.wasmedge):\n     wasmedgeup install {version}\n\nInstalling to system directories requires administrator privileges."))]
+    InsufficientPermissions {
+        path: String,
+        action: String,
+        version: String,
+        system_dir: String,
+        sudo: String,
+    },
+
     #[cfg(windows)]
     #[snafu(display("Windows Registry error: {}", source))]
     WindowsRegistry { source: std::io::Error },
@@ -40,9 +49,32 @@ pub enum Error {
     #[snafu(display("Parent directory not found for rc path: {}", path))]
     RcDirNotFound { path: String },
 
+    #[snafu(display("Checksum not found for version {} asset {}", version, asset))]
+    ChecksumNotFound { version: String, asset: String },
+
+    #[snafu(display("Checksum mismatch. Expected: {}, got: {}", expected, actual))]
+    ChecksumMismatch { expected: String, actual: String },
+
+    #[snafu(display("Invalid path {path}: {reason}"))]
+    InvalidPath { path: String, reason: String },
+
+    #[snafu(display("Failed to {action} at {path}: {source}"))]
+    Io {
+        action: String,
+        path: String,
+        source: std::io::Error,
+    },
+
     #[default]
     #[snafu(display("Unknown error occurred"))]
     Unknown,
+
+    #[cfg(windows)]
+    #[snafu(display("Error: Cannot create symbolic links.\n\nTo enable symlink creation on Windows:\n  1. Run as Administrator, or\n  2. Enable Developer Mode:\n     - Open Windows Settings\n     - Update & Security > For developers\n     - Enable 'Developer Mode'\n"))]
+    WindowsSymlinkError { version: String },
+
+    #[snafu(display("Invalid archive structure: found '{found_file}' but expected either a WasmEdge directory or standard directories (bin, lib64, include, lib).\n\nThis might indicate:\n  1. A corrupted download\n  2. An unsupported archive format\n  3. A change in the WasmEdge release structure"))]
+    InvalidArchiveStructure { found_file: String },
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,1 +1,3 @@
 pub use crate::error::*;
+
+pub const LIB_DIR: &str = "lib";

--- a/src/shell_utils/env.fish
+++ b/src/shell_utils/env.fish
@@ -5,3 +5,23 @@ if not contains "{WASMEDGE_BIN_DIR}" $PATH
     # Prepending path
     set -gx PATH "{WASMEDGE_BIN_DIR}" $PATH
 end
+
+# Handle library paths for different platforms
+switch (uname)
+    case Linux
+        if not contains "{WASMEDGE_LIB_DIR}" $LD_LIBRARY_PATH
+            if set -q LD_LIBRARY_PATH
+                set -gx LD_LIBRARY_PATH "{WASMEDGE_LIB_DIR}" $LD_LIBRARY_PATH
+            else
+                set -gx LD_LIBRARY_PATH "{WASMEDGE_LIB_DIR}"
+            end
+        end
+    case Darwin
+        if not contains "{WASMEDGE_LIB_DIR}" $DYLD_LIBRARY_PATH
+            if set -q DYLD_LIBRARY_PATH
+                set -gx DYLD_LIBRARY_PATH "{WASMEDGE_LIB_DIR}" $DYLD_LIBRARY_PATH
+            else
+                set -gx DYLD_LIBRARY_PATH "{WASMEDGE_LIB_DIR}"
+            end
+        end
+end

--- a/src/shell_utils/env.nu
+++ b/src/shell_utils/env.nu
@@ -4,3 +4,10 @@
 use std/util "path add"
 
 path add "{WASMEDGE_BIN_DIR}"
+
+# Add library path based on platform
+if (uname) == "Linux" {
+    path add "{WASMEDGE_LIB_DIR}" LD_LIBRARY_PATH
+} else if (uname) == "Darwin" {
+    path add "{WASMEDGE_LIB_DIR}" DYLD_LIBRARY_PATH
+}

--- a/src/shell_utils/env.sh
+++ b/src/shell_utils/env.sh
@@ -11,3 +11,15 @@ case ":${PATH}:" in
         export PATH="{WASMEDGE_BIN_DIR}:$PATH"
         ;;
 esac
+
+# Handle platform-specific library paths
+case $(uname) in
+    Linux)
+        # Prepending library path for Linux
+        export LD_LIBRARY_PATH="{WASMEDGE_LIB_DIR}:${LD_LIBRARY_PATH}"
+        ;;
+    Darwin)
+        # Prepending library path for macOS
+        export DYLD_LIBRARY_PATH="{WASMEDGE_LIB_DIR}:${DYLD_LIBRARY_PATH}"
+        ;;
+esac

--- a/src/shell_utils/unix.rs
+++ b/src/shell_utils/unix.rs
@@ -18,9 +18,7 @@ pub fn setup_path(install_dir: &Path) -> Result<()> {
             shell.write_script(&env_script, install_dir)?;
             written.push(env_script);
         }
-
-        let script_path = install_dir.join(env_script.name);
-        let source_line = shell.source_line(&script_path);
+        let source_line = shell.source_line(install_dir);
         let source_line_with_newline = format!("\n{}", &source_line);
 
         for rc in shell.effective_rc_files() {
@@ -86,8 +84,12 @@ pub trait UnixShell: Send + Sync {
 
     fn write_script(&self, script: &ShellScript, install_dir: &Path) -> Result<()> {
         let wasmedge_bin = format!("{}/bin", install_dir.to_string_lossy());
+        let wasmedge_lib = format!("{}/{}", install_dir.to_string_lossy(), LIB_DIR);
         let env_path = install_dir.join(script.name);
-        let env_content = script.template.replace("{WASMEDGE_BIN_DIR}", &wasmedge_bin);
+        let env_content = script
+            .template
+            .replace("{WASMEDGE_BIN_DIR}", &wasmedge_bin)
+            .replace("{WASMEDGE_LIB_DIR}", &wasmedge_lib);
 
         let mut file = std::fs::OpenOptions::new()
             .write(true)

--- a/tests/client_test.rs
+++ b/tests/client_test.rs
@@ -1,0 +1,90 @@
+use semver::Version;
+use sha2::{Digest, Sha256};
+use std::io::{Read, Seek, SeekFrom, Write};
+use tempfile::NamedTempFile;
+use wasmedgeup::{
+    api::{Asset, WasmEdgeApiClient},
+    commands::install::InstallArgs,
+    error::Error,
+};
+
+#[tokio::test]
+async fn test_checksum_verification() {
+    let mut temp_file = NamedTempFile::new().unwrap();
+    temp_file.write_all(b"test data").unwrap();
+    temp_file.seek(SeekFrom::Start(0)).unwrap();
+
+    let mut content = Vec::new();
+    temp_file.as_file_mut().read_to_end(&mut content).unwrap();
+
+    let mut hasher = Sha256::new();
+    hasher.update(&content);
+    let checksum = "916f0027a575074ce72a331777c3478d6513f786a591bd892da1a577bf2335f9"; // SHA256 of "test data"
+
+    temp_file.seek(SeekFrom::Start(0)).unwrap();
+
+    let verify_result =
+        WasmEdgeApiClient::verify_file_checksum(temp_file.as_file_mut(), checksum).await;
+
+    assert!(verify_result.is_ok(), "Checksum verification failed");
+
+    let mut temp_file = NamedTempFile::new().unwrap();
+    temp_file.write_all(b"different data").unwrap();
+    temp_file.seek(SeekFrom::Start(0)).unwrap();
+
+    let mut content = Vec::new();
+    temp_file.as_file_mut().read_to_end(&mut content).unwrap();
+    let mut hasher = Sha256::new();
+    hasher.update(&content);
+
+    temp_file.seek(SeekFrom::Start(0)).unwrap();
+
+    let result = WasmEdgeApiClient::verify_file_checksum(temp_file.as_file_mut(), checksum).await;
+    assert!(result.is_err());
+
+    match result {
+        Err(Error::ChecksumMismatch { expected, actual }) => {
+            assert_eq!(expected, checksum);
+            assert_eq!(
+                actual,
+                "608a068b33d18be838bcb07bed01e35521d30840fa24db09192e67bfd186e621"
+            ); // Actual SHA256 of "different data"
+        }
+        _ => panic!("Expected ChecksumMismatch error"),
+    }
+}
+
+#[tokio::test]
+async fn test_get_release_checksum() {
+    let client = WasmEdgeApiClient::default();
+    let version = client.latest_release().unwrap();
+    let mut args = InstallArgs {
+        version: "latest".to_string(),
+        path: None,
+        tmpdir: None,
+        os: None,
+        arch: None,
+    };
+    let os = args.os.get_or_insert_default();
+    let arch = args.arch.get_or_insert_default();
+    let asset = Asset::new(&version, os, arch);
+
+    let result = client.get_release_checksum(&version, &asset).await;
+    assert!(result.is_ok(), "Failed to get checksum: {result:?}");
+
+    let checksum = result.unwrap();
+    assert!(!checksum.is_empty(), "Checksum should not be empty");
+    assert_eq!(
+        checksum.len(),
+        64,
+        "SHA256 checksum should be 64 characters long"
+    );
+    assert!(
+        checksum.chars().all(|c| c.is_ascii_hexdigit()),
+        "Checksum should be hexadecimal"
+    );
+
+    let invalid_version = Version::new(99, 99, 99);
+    let result = client.get_release_checksum(&invalid_version, &asset).await;
+    assert!(matches!(result, Err(Error::ChecksumNotFound { .. })));
+}

--- a/tests/shell_test.rs
+++ b/tests/shell_test.rs
@@ -1,0 +1,113 @@
+use std::env;
+use tempfile::TempDir;
+use wasmedgeup::prelude::*;
+use wasmedgeup::shell_utils;
+
+mod test_utils;
+use test_utils::setup_test_environment;
+
+#[test]
+fn test_linux_library_path() {
+    if cfg!(target_os = "linux") {
+        let (_test_home, _home_path) = setup_test_environment();
+        let temp_dir = tempfile::tempdir().unwrap();
+        let install_dir = temp_dir.path().to_path_buf();
+
+        std::fs::create_dir_all(install_dir.join("bin")).unwrap();
+        std::fs::create_dir_all(install_dir.join("lib")).unwrap();
+
+        env::remove_var("LD_LIBRARY_PATH");
+
+        shell_utils::setup_path(&install_dir).unwrap();
+
+        let env_content = std::fs::read_to_string(install_dir.join("env")).unwrap();
+        assert!(env_content.contains("LD_LIBRARY_PATH"));
+        assert!(env_content.contains(&format!("{}/{}", install_dir.display(), LIB_DIR)));
+
+        println!("Env file contents:\n{env_content}");
+
+        let output = std::process::Command::new("bash")
+            .arg("-c")
+            .arg(format!("uname() {{ echo Linux; }}; export -f uname; export LD_LIBRARY_PATH='' && source {} && echo $LD_LIBRARY_PATH", install_dir.join("env").display()))
+            .output()
+            .unwrap();
+
+        let lib_path = String::from_utf8_lossy(&output.stdout);
+        println!("LD_LIBRARY_PATH: {lib_path}");
+        println!("Expected path: {}/{}", install_dir.display(), LIB_DIR);
+        assert!(lib_path.contains(&format!("{}/{}", install_dir.display(), LIB_DIR)));
+    }
+}
+
+#[test]
+fn test_macos_library_path() {
+    if cfg!(target_os = "macos") {
+        let (_test_home, _home_path) = setup_test_environment();
+        let temp_dir = tempfile::tempdir().unwrap();
+        let install_dir = temp_dir.path().to_path_buf();
+
+        std::fs::create_dir_all(install_dir.join("bin")).unwrap();
+        std::fs::create_dir_all(install_dir.join("lib")).unwrap();
+
+        env::remove_var("DYLD_LIBRARY_PATH");
+
+        shell_utils::setup_path(&install_dir).unwrap();
+
+        let env_content = std::fs::read_to_string(install_dir.join("env")).unwrap();
+        assert!(env_content.contains("DYLD_LIBRARY_PATH"));
+        assert!(env_content.contains(&format!("{}/{}", install_dir.display(), LIB_DIR)));
+
+        let output = std::process::Command::new("bash")
+            .arg("-c")
+            .arg(format!("uname() {{ echo Darwin; }}; export -f uname; export DYLD_LIBRARY_PATH='' && source {} && echo $DYLD_LIBRARY_PATH", install_dir.join("env").display()))
+            .output()
+            .unwrap();
+
+        let lib_path = String::from_utf8_lossy(&output.stdout);
+        assert!(lib_path.contains(&format!("{}/{}", install_dir.display(), LIB_DIR)));
+    }
+}
+
+#[test]
+fn test_library_path_append() {
+    let (_test_home, _home_path) = setup_test_environment();
+    let temp_dir = TempDir::new().unwrap();
+    let install_dir = temp_dir.path().to_path_buf();
+
+    std::fs::create_dir_all(install_dir.join("bin")).unwrap();
+    std::fs::create_dir_all(install_dir.join("lib")).unwrap();
+
+    let existing_path = "/existing/path";
+
+    shell_utils::setup_path(&install_dir).unwrap();
+
+    if cfg!(target_os = "linux") {
+        let output = std::process::Command::new("bash")
+            .arg("-c")
+            .arg(format!(
+                "uname() {{ echo Linux; }}; export -f uname; export LD_LIBRARY_PATH='{}' && source {} && echo $LD_LIBRARY_PATH",
+                existing_path,
+                install_dir.join("env").display()
+            ))
+            .output()
+            .unwrap();
+
+        let lib_path = String::from_utf8_lossy(&output.stdout);
+        assert!(lib_path.contains(&format!("{}/{}", install_dir.display(), LIB_DIR)));
+        assert!(lib_path.contains(existing_path));
+    } else if cfg!(target_os = "macos") {
+        let output = std::process::Command::new("bash")
+            .arg("-c")
+            .arg(format!(
+                "uname() {{ echo Darwin; }}; export -f uname; export DYLD_LIBRARY_PATH='{}' && source {} && echo $DYLD_LIBRARY_PATH",
+                existing_path,
+                install_dir.join("env").display()
+            ))
+            .output()
+            .unwrap();
+
+        let lib_path = String::from_utf8_lossy(&output.stdout);
+        assert!(lib_path.contains(&format!("{}/{}", install_dir.display(), LIB_DIR)));
+        assert!(lib_path.contains(existing_path));
+    }
+}

--- a/tests/test_utils.rs
+++ b/tests/test_utils.rs
@@ -1,0 +1,25 @@
+use std::path::PathBuf;
+
+pub fn setup_test_environment() -> (tempfile::TempDir, PathBuf) {
+    let test_home = tempfile::tempdir().unwrap();
+    let test_home_path = test_home.path().to_path_buf();
+
+    // Set up environment variables based on platform
+    #[cfg(windows)]
+    {
+        std::env::set_var("USERPROFILE", &test_home_path);
+    }
+    #[cfg(unix)]
+    {
+        std::env::set_var("HOME", &test_home_path);
+        std::env::set_var("ZDOTDIR", &test_home_path);
+
+        let zshenv_path = test_home_path.join(".zshenv");
+        if let Some(parent) = zshenv_path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(&zshenv_path, "").unwrap();
+    }
+
+    (test_home, test_home_path)
+}


### PR DESCRIPTION
## Which GitHub issue does this PR close?

Closes #90 <!-- Add issue number here, e.g., Closes #123 -->

## Why is this needed?
To fix the installation function and add checksum verification.
<!-- Briefly explain the motivation behind this change. -->

## What does this PR change?
The PR fixes the following 
```
Incorrect temporary directory handling
Failed extractions and file copying
Missing checksum verification
Linker errors (libwasmedge.so.0 not found)
Wrong environment setup for Unix (It's sourcing bin/env/env, but /bin/env is the file )
```
<!-- Summarize the key changes included in this PR. -->

## How has this been tested?
Added unit tests for the checksum verification. 
<!-- Describe the testing process. If no tests were added, explain why (e.g., already covered, not applicable). -->

Related : [Wasmedge#4351](https://github.com/WasmEdge/WasmEdge/issues/4351)
