### PR TITLE
feat(ci): add ci clippy check and fix warnings

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -35,6 +35,23 @@ jobs:
       - name: Check formatting (rustfmt)
         run: cargo fmt --all --check
 
+  clippy:
+    runs-on: ubuntu-latest
+    name: Clippy
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Setup rust toolchain
+        uses: ./.github/actions/setup-rust
+
+      - name: Run clippy
+        run: cargo clippy --all-targets --all-features -- -D warnings
+
   build:
     strategy:
       matrix:

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -128,10 +128,10 @@ impl Asset {
 
         match (os, arch) {
             (OS::Ubuntu, Arch::X86_64) => {
-                format!("WasmEdge-{}-ubuntu20.04_x86_64.tar.gz", version)
+                format!("WasmEdge-{version}-ubuntu20.04_x86_64.tar.gz")
             }
             (OS::Ubuntu, Arch::Aarch64) if is_arm_ubuntu_supported(version) => {
-                format!("WasmEdge-{}-ubuntu20.04_aarch64.tar.gz", version)
+                format!("WasmEdge-{version}-ubuntu20.04_aarch64.tar.gz")
             }
             (OS::Linux | OS::Ubuntu, arch) => {
                 let manylinux_version = if is_manylinux2014_supported(version) {
@@ -143,16 +143,16 @@ impl Asset {
                     Arch::X86_64 => "x86_64",
                     Arch::Aarch64 => "aarch64",
                 };
-                format!("WasmEdge-{}-{}_{}.tar.gz", version, manylinux_version, arch)
+                format!("WasmEdge-{version}-{manylinux_version}_{arch}.tar.gz")
             }
             (OS::Darwin, Arch::X86_64) => {
-                format!("WasmEdge-{}-darwin_x86_64.tar.gz", version)
+                format!("WasmEdge-{version}-darwin_x86_64.tar.gz")
             }
             (OS::Darwin, Arch::Aarch64) => {
-                format!("WasmEdge-{}-darwin_arm64.tar.gz", version)
+                format!("WasmEdge-{version}-darwin_arm64.tar.gz")
             }
             (OS::Windows, _) => {
-                format!("WasmEdge-{}-windows.zip", version)
+                format!("WasmEdge-{version}-windows.zip")
             }
         }
     }
@@ -161,9 +161,9 @@ impl Asset {
         use TargetOS as OS;
 
         match os {
-            OS::Linux | OS::Ubuntu => format!("WasmEdge-{}-Linux", version),
-            OS::Darwin => format!("WasmEdge-{}-Darwin", version),
-            OS::Windows => format!("WasmEdge-{}-Windows", version),
+            OS::Linux | OS::Ubuntu => format!("WasmEdge-{version}-Linux"),
+            OS::Darwin => format!("WasmEdge-{version}-Darwin"),
+            OS::Windows => format!("WasmEdge-{version}-Windows"),
         }
     }
 }

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -22,7 +22,7 @@ impl CommandExecutor for ListArgs {
         let latest_release = ctx.client.latest_release()?;
 
         for gh_release in releases.into_iter() {
-            print!("{}", gh_release);
+            print!("{gh_release}");
             if gh_release == latest_release {
                 println!(" <- latest");
             } else {

--- a/src/shell_utils/unix.rs
+++ b/src/shell_utils/unix.rs
@@ -305,7 +305,7 @@ fn append_file(path: &Path, line: &str) -> Result<()> {
         .create(true)
         .open(path)?;
 
-    writeln!(file, "{}", line)?;
+    writeln!(file, "{line}")?;
 
     file.sync_data()?;
 


### PR DESCRIPTION
## Why is this needed?
- Added Clippy to the CI workflow to enhance code quality by catching common mistakes and enforcing Rust best practices
- Clippy provides additional static analysis beyond what the Rust compiler checks, helping maintain high code quality standards
- Having Clippy in CI ensures all new code contributions meet these quality standards automatically

<!-- Briefly explain the motivation behind this change. -->

## What does this PR change?
- Added a new `clippy` job to the GitHub Actions workflow
- The job runs `cargo clippy` with the following configuration:
  - Checks all targets and features
  - Treats warnings as errors (`-D warnings`)

<!-- Summarize the key changes included in this PR. -->

## How has this been tested?
 Tested locally using `cargo clippy --workspace --all-targets -- -D warnings` which passed successfully
- CI workflow has been tested on the forked repository, and all checks passed
<!-- Describe the testing process. If no tests were added, explain why (e.g., already covered, not applicable). -->

Related: [WasmEgde#4351](https://github.com/WasmEdge/WasmEdge/issues/4351)
