### PR TITLE
feat: implement version management using use and list 

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -15,9 +15,10 @@
 wasmedgeup should have the following commands:
 
 1. `install`: Installs a specified (or latest) WasmEdge runtime version.
-2. `list`: Lists available WasmEdge releases.
-3. `remove`: Uninstalls a specific version of WasmEdge from the system, removing installed files.
-4. `help`: Shows a usage overview or help message for each subcommand.
+2. `list`: Lists installed WasmEdge versions (or remote releases with `--remote`).
+3. `use`: Switches to a specified WasmEdge runtime version installed on this machine.
+4. `remove`: Uninstalls a specific version of WasmEdge from the system, removing installed files.
+5. `help`: Shows a usage overview or help message for each subcommand.
 
 ##### Command `Install`
 
@@ -47,10 +48,35 @@ wasmedgeup should have the following commands:
 
 ##### Command `List`
 
-Lists available WasmEdge releases. By default, only stable releases are shown.
+Lists installed WasmEdge versions under the target directory. The current active version is marked with `<- current`.
 
+Options
+
+- `-r`, `--remote`
+  - Description: Show remote WasmEdge releases from GitHub instead of installed versions.
+  - Default: off
 - `-a`, `--all`
-  - Description: Include pre-release versions (alpha, beta, rc).
+  - Description: When used with `--remote`, include pre-release versions (alpha, beta, rc).
+  - Default: off
+- `-p`, `--path`
+  - Description: Set the installed location to inspect for local versions
+  - Usage: `--path /usr/local`
+  - Default: `$HOME/.wasmedge`
+
+##### Command `Use`
+
+Switches to a specified WasmEdge runtime version already installed on this machine. This updates the symlinks in the target directory to point to the selected version.
+
+Arguments
+
+1. `use <specific version, e.g. 0.15.0>`: Switches the current version to the specified installed version.
+
+Options
+
+- `-p`, `--path`
+  - Description: Set the installed location
+  - Usage: `--path /usr/local`
+  - Default: `$HOME/.wasmedge`
 
 #### Global Options
 

--- a/src/bin/wasmedgeup.rs
+++ b/src/bin/wasmedgeup.rs
@@ -7,7 +7,7 @@ use wasmedgeup::prelude::*;
 #[tokio::main]
 async fn main() -> Result<()> {
     let cli = Cli::parse();
-    let ctx = cli.context(Default::default());
+    let ctx = cli.context();
 
     init_tracing(cli.verbose);
 

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -1,32 +1,90 @@
 use crate::{api::ReleasesFilter, cli::CommandContext, prelude::*};
 use clap::Parser;
+use std::path::PathBuf;
+use tokio::fs;
 
-use crate::cli::CommandExecutor;
+use crate::{cli::CommandExecutor, commands::default_path};
 
 #[derive(Debug, Parser)]
 pub struct ListArgs {
-    /// Include pre-release versions (alpha, beta, rc).
+    /// Show remote versions instead of installed versions
+    #[arg(long, default_value_t = false)]
+    remote: bool,
+
+    /// Include pre-release versions (alpha, beta, rc) when listing remote versions
     #[arg(short, long, default_value_t = false)]
     all: bool,
+
+    /// Set the install location for the WasmEdge runtime
+    ///
+    /// Defaults to `$HOME/.wasmedge` on Unix-like systems and `%HOME%\.wasmedge` on Windows.
+    #[arg(short, long)]
+    path: Option<PathBuf>,
 }
 
 impl CommandExecutor for ListArgs {
     async fn execute(self, ctx: CommandContext) -> Result<()> {
-        let filter = if self.all {
-            ReleasesFilter::All
-        } else {
-            ReleasesFilter::Stable
-        };
-
-        let releases = ctx.client.releases(filter, 10)?;
-        let latest_release = ctx.client.latest_release()?;
-
-        for gh_release in releases.into_iter() {
-            print!("{gh_release}");
-            if gh_release == latest_release {
-                println!(" <- latest");
+        if self.remote {
+            let filter = if self.all {
+                ReleasesFilter::All
             } else {
-                println!();
+                ReleasesFilter::Stable
+            };
+
+            let releases = ctx.client.releases(filter, 10)?;
+            let latest_release = ctx.client.latest_release()?;
+
+            for gh_release in releases.into_iter() {
+                print!("{gh_release}");
+                if gh_release == latest_release {
+                    println!(" <- latest");
+                } else {
+                    println!();
+                }
+            }
+        } else {
+            let target_dir = self.path.unwrap_or_else(default_path);
+            let versions_dir = target_dir.join("versions");
+
+            let current_version =
+                if let Ok(link_target) = fs::read_link(target_dir.join("bin")).await {
+                    let bin_path = target_dir.join("bin");
+                    let resolved = if link_target.is_absolute() {
+                        link_target
+                    } else {
+                        bin_path.parent().unwrap_or(&target_dir).join(link_target)
+                    };
+                    resolved
+                        .strip_prefix(&versions_dir)
+                        .ok()
+                        .and_then(|p| p.components().next())
+                        .map(|c| c.as_os_str().to_string_lossy().to_string())
+                } else {
+                    None
+                };
+
+            if let Ok(mut entries) = fs::read_dir(&versions_dir).await {
+                let mut versions = Vec::new();
+                while let Ok(Some(entry)) = entries.next_entry().await {
+                    if let Ok(file_type) = entry.file_type().await {
+                        if file_type.is_dir() {
+                            if let Some(version) = entry.file_name().to_str() {
+                                versions.push(version.to_string());
+                            }
+                        }
+                    }
+                }
+
+                versions.sort_by(|a, b| b.cmp(a));
+
+                for version in versions {
+                    print!("{version}");
+                    if Some(version.clone()) == current_version {
+                        println!(" <- current");
+                    } else {
+                        println!();
+                    }
+                }
             }
         }
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,4 +1,12 @@
+use std::path::PathBuf;
+
 pub mod install;
 pub mod list;
 pub mod plugin;
 pub mod remove;
+pub mod use_cmd;
+
+fn default_path() -> PathBuf {
+    let home_dir = dirs::home_dir().expect("home_dir should be present");
+    home_dir.join(".wasmedge")
+}

--- a/src/commands/use_cmd.rs
+++ b/src/commands/use_cmd.rs
@@ -1,0 +1,45 @@
+use clap::Parser;
+use std::path::PathBuf;
+
+use crate::{
+    cli::{CommandContext, CommandExecutor},
+    commands::default_path,
+    fs,
+    prelude::*,
+};
+
+#[derive(Debug, Parser)]
+pub struct UseArgs {
+    /// WasmEdge version to use, e.g. `latest`, `0.14.1`, `0.15.0`, etc.
+    pub version: String,
+
+    /// Set the install location for the WasmEdge runtime
+    ///
+    /// Defaults to `$HOME/.wasmedge` on Unix-like systems and `%HOME%\.wasmedge` on Windows.
+    #[arg(short, long)]
+    pub path: Option<PathBuf>,
+}
+
+impl CommandExecutor for UseArgs {
+    #[tracing::instrument(name = "use", skip_all, fields(version = self.version))]
+    async fn execute(self, ctx: CommandContext) -> Result<()> {
+        let version = ctx.client.resolve_version(&self.version).inspect_err(
+            |e| tracing::error!(error = %e.to_string(), "Failed to resolve version"),
+        )?;
+        tracing::debug!(%version, "Resolved version for use");
+
+        let target_dir = self.path.unwrap_or_else(default_path);
+
+        let version_dir = target_dir.join("versions").join(version.to_string());
+        if !version_dir.exists() {
+            return Err(Error::VersionNotFound {
+                version: version.to_string(),
+            });
+        }
+
+        fs::create_version_symlinks(&target_dir, &version.to_string()).await?;
+
+        tracing::info!(%version, "Switched to WasmEdge version");
+        Ok(())
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,6 +3,9 @@ use snafu::Snafu;
 #[derive(Debug, Default, Snafu)]
 #[snafu(visibility(pub))]
 pub enum Error {
+    #[snafu(display("Version {version} not found in wasmedge installation"))]
+    VersionNotFound { version: String },
+
     #[snafu(display("Unable to fetch resource '{}' for git", resource))]
     Git {
         source: git2::Error,

--- a/tests/use_test.rs
+++ b/tests/use_test.rs
@@ -1,0 +1,134 @@
+use std::path::Path;
+use wasmedgeup::{
+    api::{releases, ReleasesFilter, WasmEdgeApiClient},
+    cli::{CommandContext, CommandExecutor},
+    commands::use_cmd::UseArgs,
+};
+
+mod test_utils;
+
+const WASM_EDGE_GIT_URL: &str = "https://github.com/WasmEdge/WasmEdge.git";
+
+#[tokio::test]
+async fn test_use_version() {
+    let (_tempdir, test_home) = test_utils::setup_test_environment();
+
+    let versions = ["0.14.1", "0.15.0"];
+    for version in &versions {
+        let version_dir = test_home.join("versions").join(version);
+        let bin_dir = version_dir.join("bin");
+        let lib_dir = version_dir.join("lib");
+        let include_dir = version_dir.join("include");
+
+        tokio::fs::create_dir_all(&bin_dir).await.unwrap();
+        tokio::fs::create_dir_all(&lib_dir).await.unwrap();
+        tokio::fs::create_dir_all(&include_dir).await.unwrap();
+
+        tokio::fs::write(bin_dir.join("wasmedge"), format!("mock wasmedge {version}"))
+            .await
+            .unwrap();
+    }
+    let args = UseArgs {
+        version: "0.14.1".to_string(),
+        path: Some(test_home.clone()),
+    };
+    let ctx = CommandContext::default();
+    args.execute(ctx).await.unwrap();
+
+    verify_symlinks(&test_home, "0.14.1").await;
+
+    let args = UseArgs {
+        version: "0.15.0".to_string(),
+        path: Some(test_home.clone()),
+    };
+    let ctx = CommandContext::default();
+    args.execute(ctx).await.unwrap();
+
+    verify_symlinks(&test_home, "0.15.0").await;
+}
+
+#[tokio::test]
+async fn test_use_latest_version() {
+    let (_tempdir, test_home) = test_utils::setup_test_environment();
+
+    let all_releases = releases::get_all(WASM_EDGE_GIT_URL, ReleasesFilter::Stable).unwrap();
+    assert!(!all_releases.is_empty());
+    let latest_version = &all_releases[0].to_string();
+    let version_dir = test_home.join("versions").join(latest_version);
+    let bin_dir = version_dir.join("bin");
+    let lib_dir = version_dir.join("lib");
+    let include_dir = version_dir.join("include");
+
+    tokio::fs::create_dir_all(&bin_dir).await.unwrap();
+    tokio::fs::create_dir_all(&lib_dir).await.unwrap();
+    tokio::fs::create_dir_all(&include_dir).await.unwrap();
+
+    tokio::fs::write(
+        bin_dir.join("wasmedge"),
+        format!("mock wasmedge {latest_version}"),
+    )
+    .await
+    .unwrap();
+
+    let args = UseArgs {
+        version: "latest".to_string(),
+        path: Some(test_home.clone()),
+    };
+    let ctx = CommandContext {
+        client: WasmEdgeApiClient::default(),
+        no_progress: true,
+    };
+    args.execute(ctx).await.unwrap();
+
+    verify_symlinks(&test_home, latest_version).await;
+}
+
+#[tokio::test]
+async fn test_use_nonexistent_version() {
+    let (_tempdir, test_home) = test_utils::setup_test_environment();
+
+    let args = UseArgs {
+        version: "0.99.99".to_string(),
+        path: Some(test_home),
+    };
+    let ctx = CommandContext::default();
+    let result = args.execute(ctx).await;
+
+    assert!(result.is_err(), "Using non-existent version should fail");
+    assert!(matches!(
+        result.unwrap_err(),
+        wasmedgeup::error::Error::VersionNotFound { version: _ }
+    ));
+}
+
+async fn verify_symlinks(base_dir: &Path, expected_version: &str) {
+    for dir in ["bin", "lib", "include"] {
+        let symlink = base_dir.join(dir);
+        assert!(symlink.exists(), "Symlink {dir} should exist");
+
+        let target = tokio::fs::read_link(&symlink).await.unwrap();
+
+        #[cfg(windows)]
+        {
+            let expected_rel = std::path::Path::new("versions")
+                .join(expected_version)
+                .join(dir);
+            assert!(
+                target.ends_with(&expected_rel),
+                "Symlink {dir} should point to version {expected_version}. target='{}' expected_suffix='{}'",
+                target.display(),
+                expected_rel.display()
+            );
+        }
+
+        #[cfg(unix)]
+        {
+            let expected = format!("versions/{expected_version}/{dir}");
+            assert_eq!(
+                target.to_string_lossy(),
+                expected,
+                "Symlink {dir} should point to version {expected_version}"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Why is this needed?
To enable users to manage multiple WasmEdge versions on their system. This allows developers to switch between different versions for testing or compatibility purposes.

<!-- Briefly explain the motivation behind this change. -->

## What does this PR change?
- Implements versioned installation structure (`~/.wasmedge/versions/x.y.z/`)
- Adds version management commands:
  - `wasmedgeup list` - shows installed versions
  - `wasmedgeup use <version>` - switches active version
- Adds symlink management for version switching

<!-- Summarize the key changes included in this PR. -->

## How has this been tested?
- Tested locally on ubuntu.
- Integration tests for version switching
- CI testing on forked repository. [#PR](https://github.com/Arshdeep54/wasmedgeup/pull/5)

<!-- Describe the testing process. If no tests were added, explain why (e.g., already covered, not applicable). -->

## Anything else?
For this, we need to restrict users from installing all the versions using different paths.
There will a base_directory (`$HOME/.wasmedge` by default) and versions directory similar to [this](https://github.com/WasmEdge/wasmedgeup/issues/90#issuecomment-3305754939).
Related : [WasmEdge#4351](https://github.com/WasmEdge/WasmEdge/issues/4351)
<!-- Include screenshots, documentation updates, or anything else relevant. -->
