### PR TITLE
feat: detect system specs and plugin list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+/.idea

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,6 +29,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -107,6 +116,12 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
@@ -159,6 +174,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "chrono"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "serde",
+ "windows-link 0.2.0",
+]
+
+[[package]]
 name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -166,6 +193,17 @@ checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common",
  "inout",
+]
+
+[[package]]
+name = "cl3"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b823f24e72fa0c68aa14a250ae1c0848e68d4ae188b71c3972343e45b46f8644"
+dependencies = [
+ "libc",
+ "opencl-sys",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -199,7 +237,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -283,6 +321,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -290,6 +353,41 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -315,7 +413,7 @@ checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -358,8 +456,14 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "encode_unicode"
@@ -507,7 +611,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -585,7 +689,7 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2deb07a133b1520dc1a5690e9bd08950108873d7ed5de38dcc74d3b5ebffa110"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.0",
  "libc",
  "libgit2-sys",
  "log",
@@ -644,6 +748,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest",
+]
+
+[[package]]
+name = "home"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
+dependencies = [
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -766,6 +879,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core 0.62.1",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "icu_collections"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -880,8 +1017,14 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -1018,12 +1161,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "libloading"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
+dependencies = [
+ "cfg-if",
+ "winapi",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.0",
  "libc",
  "redox_syscall",
 ]
@@ -1062,6 +1215,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1157,6 +1316,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ntapi"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1172,10 +1340,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "nvml-wrapper"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd21b9f5a1cce3c3515c9ffa85f5c7443e07162dae0ccf4339bb7ca38ad3454"
+dependencies = [
+ "bitflags 1.3.2",
+ "libloading",
+ "nvml-wrapper-sys",
+ "static_assertions",
+ "thiserror 1.0.69",
+ "wrapcenum-derive",
+]
+
+[[package]]
+name = "nvml-wrapper-sys"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c961a2ea9e91c59a69b78e69090f6f5b867bb46c0c56de9482da232437c4987e"
+dependencies = [
+ "libloading",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cde51589ab56b20a6f686b2c68f7a0bd6add753d697abf720d63f8db3ab7b1ad"
+
+[[package]]
+name = "opencl-sys"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de15dd01496ae90c5799f5266184ab020082b4065800ff0b732f489371d0e5cf"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "opencl3"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26ab4a90cb496f787d3934deb0c54fa9d65e7bed710c10071234aab0196fba04"
+dependencies = [
+ "cl3",
+ "libc",
+]
 
 [[package]]
 name = "openssl"
@@ -1183,7 +1402,7 @@ version = "0.10.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fedfea7d58a1f73118430a55da6a286e7b044961736ce96a16a17068ea25e5da"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -1200,7 +1419,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1336,12 +1555,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
+name = "raw-cpuid"
+version = "10.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c297679cb867470fa8c9f67dbba74a78d78e3e98d7cf2b08d6d71540f797332"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
+name = "rayon"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2f103c6d277498fbceb16e84d317e2a400f160f46904d5f5410848c829511a3"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.0",
 ]
 
 [[package]]
@@ -1352,7 +1600,7 @@ checksum = "dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b"
 dependencies = [
  "getrandom 0.2.15",
  "libredox",
- "thiserror",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -1469,7 +1717,7 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version",
- "syn",
+ "syn 2.0.100",
  "unicode-ident",
 ]
 
@@ -1484,14 +1732,27 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.9.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d97817398dd4bb2e6da002002db259209759911da105da92bec29ccb12cf58bf"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.0",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.9.3",
  "windows-sys 0.59.0",
 ]
 
@@ -1582,7 +1843,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -1622,7 +1883,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1671,7 +1932,7 @@ checksum = "5d69265a08751de7844521fd15003ae0a888e035773ba05695c5c759a6f89eef"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1750,7 +2011,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1780,6 +2041,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1790,6 +2057,17 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -1819,7 +2097,22 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.30.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a5b4ddaee55fb2bea2bf0e5000747e5f5c0de765e5a5ff87f4cd106439f4bb3"
+dependencies = [
+ "cfg-if",
+ "core-foundation-sys",
+ "libc",
+ "ntapi",
+ "once_cell",
+ "rayon",
+ "windows 0.52.0",
 ]
 
 [[package]]
@@ -1828,7 +2121,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.0",
  "core-foundation",
  "system-configuration-sys",
 ]
@@ -1863,8 +2156,17 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.2",
  "once_cell",
- "rustix",
+ "rustix 1.0.5",
  "windows-sys 0.61.0",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
 ]
 
 [[package]]
@@ -1873,7 +2175,18 @@ version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.12",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1884,7 +2197,7 @@ checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1949,7 +2262,7 @@ checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2023,7 +2336,7 @@ version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5cc2d9e086a412a451384326f521c8123a99a466b329941a9403696bff9b0da2"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.0",
  "bytes",
  "futures-util",
  "http",
@@ -2066,7 +2379,7 @@ checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2244,7 +2557,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
  "wasm-bindgen-shared",
 ]
 
@@ -2279,7 +2592,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2304,12 +2617,18 @@ dependencies = [
  "git2",
  "hex",
  "indicatif",
+ "nvml-wrapper",
+ "opencl3",
+ "raw-cpuid",
  "reqwest",
  "rstest",
  "semver",
+ "serde",
+ "serde_json",
  "serial_test",
  "sha2",
  "snafu",
+ "sysinfo",
  "tar",
  "tempfile",
  "tokio",
@@ -2317,7 +2636,9 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "walkdir",
+ "which",
  "winreg",
+ "wmi",
  "zip",
 ]
 
@@ -2342,12 +2663,133 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "6.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ee928febd44d98f2f459a4a79bd4d928591333a494a10a868418ac1b39cf1f"
+dependencies = [
+ "either",
+ "home",
+ "rustix 0.38.44",
+ "winsafe",
+]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
+dependencies = [
+ "windows-implement 0.48.0",
+ "windows-interface 0.48.0",
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
+dependencies = [
+ "windows-core 0.52.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6844ee5416b285084d3d3fffd743b925a6c9385455f64f6d4fa3031c4c2749a9"
+dependencies = [
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
+ "windows-link 0.2.0",
+ "windows-result 0.4.0",
+ "windows-strings 0.5.0",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e2ee588991b9e7e6c8338edf3333fbe4da35dc72092643958ebb43f0ab2c49c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6fb8df20c9bcaa8ad6ab513f7b40104840c8867d5751126e4df3b08388d0cc7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2368,8 +2810,8 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3"
 dependencies = [
- "windows-result",
- "windows-strings",
+ "windows-result 0.3.2",
+ "windows-strings 0.3.1",
  "windows-targets 0.53.0",
 ]
 
@@ -2383,12 +2825,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-result"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7084dcc306f89883455a206237404d3eaf961e5bd7e0f312f7c91f57eb44167f"
+dependencies = [
+ "windows-link 0.2.0",
+]
+
+[[package]]
 name = "windows-strings"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
 dependencies = [
  "windows-link 0.1.1",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7218c655a553b0bed4426cf54b20d7ba363ef543b52d515b3e48d7fd55318dda"
+dependencies = [
+ "windows-link 0.2.0",
 ]
 
 [[package]]
@@ -2416,6 +2876,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e201184e40b2ede64bc2ea34968b28e33622acdbbf37104f0e4a33f7abe657aa"
 dependencies = [
  "windows-link 0.2.0",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -2452,6 +2927,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -2464,6 +2945,12 @@ checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -2473,6 +2960,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2500,6 +2993,12 @@ checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -2509,6 +3008,12 @@ name = "windows_i686_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2524,6 +3029,12 @@ checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -2533,6 +3044,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -2566,12 +3083,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
+
+[[package]]
 name = "wit-bindgen-rt"
 version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.0",
+]
+
+[[package]]
+name = "wmi"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daffb44abb7d2e87a1233aa17fdbde0d55b890b32a23a1f908895b87fa6f1a00"
+dependencies = [
+ "chrono",
+ "futures",
+ "log",
+ "serde",
+ "thiserror 1.0.69",
+ "windows 0.48.0",
+]
+
+[[package]]
+name = "wrapcenum-derive"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a76ff259533532054cfbaefb115c613203c73707017459206380f03b3b3f266e"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2593,7 +3142,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d65cbf2f12c15564212d48f4e3dfb87923d25d611f2aed18f4cb23f0413d89e"
 dependencies = [
  "libc",
- "rustix",
+ "rustix 1.0.5",
 ]
 
 [[package]]
@@ -2616,7 +3165,7 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
  "synstructure",
 ]
 
@@ -2637,7 +3186,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
  "synstructure",
 ]
 
@@ -2658,7 +3207,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2680,7 +3229,7 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,11 @@ walkdir = "2.5.0"
 sha2 = "0.10"
 serial_test = "3.2.0"
 hex = "0.4"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+sysinfo = "0.30"
+which = "6"
+raw-cpuid = "10"
 
 [target.'cfg(unix)'.dependencies]
 flate2 = "1.1.5"
@@ -34,6 +39,16 @@ tar = "0.4.44"
 [target.'cfg(windows)'.dependencies]
 zip = "6.0.0"
 winreg = "0.55"
+nvml-wrapper = "0.9"
+wmi = "0.12"
+
+[target.'cfg(windows)'.dependencies.opencl3]
+version = "0.9"
+optional = true
+
+[features]
+default = []
+opencl = ["dep:opencl3"]
 
 [dev-dependencies]
 rstest = "0.26.1"

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -365,3 +365,9 @@ pub fn latest_installed_version(versions_dir: &Path) -> Result<Option<Version>> 
     versions.sort_by(|a, b| b.cmp(a));
     Ok(versions.into_iter().next())
 }
+
+pub fn runtime_ge_015(runtime: &str) -> bool {
+    semver::Version::parse(runtime)
+        .map(|v| v >= semver::Version::new(0, 15, 0))
+        .unwrap_or(true)
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -96,7 +96,7 @@ impl CommandExecutor for Commands {
             Install(args) => args.execute(ctx).await,
             Use(args) => args.execute(ctx).await,
             Remove(args) => args.execute(ctx).await,
-            _ => todo!(),
+            Plugin(args) => args.execute(ctx).await,
         }
     }
 }

--- a/src/commands/plugin/list.rs
+++ b/src/commands/plugin/list.rs
@@ -1,0 +1,311 @@
+use crate::api::runtime_ge_015;
+use crate::cli::{CommandContext, CommandExecutor};
+use crate::prelude::*;
+use crate::system;
+use crate::system::plugins::platform_key_from_specs;
+use clap::Args;
+use serde_json::Value;
+use std::cmp::Ordering;
+use std::collections::HashSet;
+
+const UA: &str = "wasmedgeup";
+const GH_RELEASE_TAG_API: &str = "https://api.github.com/repos/WasmEdge/WasmEdge/releases/tags";
+const GH_RELEASE_DOWNLOAD_BASE: &str = "https://github.com/WasmEdge/WasmEdge/releases/download";
+const ASSET_PREFIX: &str = "WasmEdge-plugin-";
+const TAR_GZ: &str = ".tar.gz";
+const ZIP: &str = ".zip";
+
+const UBUNTU20_PREFIX: &str = "ubuntu20_04_";
+const UBUNTU22_PREFIX: &str = "ubuntu22_04_";
+const MANYLINUX2014_PREFIX: &str = "manylinux2014_";
+const MANYLINUX_2_28_PREFIX: &str = "manylinux_2_28_";
+
+#[derive(Debug, Args)]
+pub struct PluginListArgs {
+    /// Show all (including assets that are not found for this runtime/platform)
+    #[arg(long)]
+    all: bool,
+
+    /// Override the WasmEdge runtime version to check (e.g., 0.15.0)
+    #[arg(long)]
+    runtime: Option<String>,
+
+    /// Filter by a single plugin name
+    #[arg(long)]
+    name: Option<String>,
+}
+
+impl CommandExecutor for PluginListArgs {
+    async fn execute(self, _ctx: CommandContext) -> Result<()> {
+        let spec = system::detect();
+        let platform = match platform_key_from_specs(&spec.os) {
+            Ok(p) => p,
+            Err(e) => {
+                eprintln!("{e}");
+                return Err(e);
+            }
+        };
+
+        let runtime = if let Some(r) = self.runtime {
+            r
+        } else {
+            match system::toolchain::get_installed_wasmedge_version() {
+                Ok(v) => v,
+                Err(e) => {
+                    eprintln!("WasmEdge runtime not found: {e}. Install a runtime first (e.g., wasmedgeup install 0.15.0).");
+                    return Err(Error::RuntimeNotFound);
+                }
+            }
+        };
+
+        let cuda_hint = spec.accelerators.cuda_available;
+        let noavx_hint = matches!(spec.cpu.class, crate::system::spec::CpuClass::NoAvx)
+            || !spec
+                .cpu
+                .features
+                .contains(&crate::system::spec::CpuFeature::AVX);
+
+        let assets = match fetch_release_assets(&runtime).await {
+            Ok(v) => v,
+            Err(_) => {
+                eprintln!("failed to fetch release assets for tag {runtime}");
+                Vec::new()
+            }
+        };
+
+        let mut name_set: HashSet<String> = HashSet::new();
+        for a in &assets {
+            if a.version == runtime {
+                name_set.insert(a.plugin.clone());
+            }
+        }
+
+        let mut candidates: Vec<String> = name_set.into_iter().collect();
+
+        if let Some(filter) = &self.name {
+            candidates.retain(|p| p == filter);
+        }
+
+        candidates.sort_by(|a, b| order_plugins(a, b, cuda_hint, noavx_hint));
+
+        let platform_candidates = platform_fallbacks(&platform, &runtime);
+        let mut rows: Vec<Row> = Vec::new();
+
+        for a in &assets {
+            if a.version != runtime {
+                continue;
+            }
+            if !platform_candidates.iter().any(|p| p == &a.platform) {
+                continue;
+            }
+            if let Some(filter) = &self.name {
+                if &a.plugin != filter {
+                    continue;
+                }
+            }
+            rows.push(Row {
+                name: a.plugin.clone(),
+                version: a.version.clone(),
+                status: "available".to_string(),
+            });
+        }
+
+        if rows.is_empty() && self.all {
+            for name in &candidates {
+                let probes = if name == "wasi_nn-ggml" {
+                    if cuda_hint {
+                        vec!["wasi_nn-ggml-cuda", "wasi_nn-ggml"]
+                    } else if noavx_hint {
+                        vec!["wasi_nn-ggml-noavx", "wasi_nn-ggml"]
+                    } else {
+                        vec!["wasi_nn-ggml"]
+                    }
+                } else {
+                    vec![name.as_str()]
+                };
+                for probe in probes {
+                    for plat in &platform_candidates {
+                        let url_targz = format!(
+                            "{GH_RELEASE_DOWNLOAD_BASE}/{runtime}/{ASSET_PREFIX}{probe}-{runtime}-{plat}{TAR_GZ}"
+                        );
+                        let url_zip = format!(
+                            "{GH_RELEASE_DOWNLOAD_BASE}/{runtime}/{ASSET_PREFIX}{probe}-{runtime}-{plat}{ZIP}"
+                        );
+                        let available = head_ok(&url_targz).await || head_ok(&url_zip).await;
+                        rows.push(Row {
+                            name: probe.to_string(),
+                            version: runtime.clone(),
+                            status: if available {
+                                format!("available ({plat})")
+                            } else {
+                                format!("not found ({plat})")
+                            },
+                        });
+                    }
+                }
+            }
+        }
+
+        rows.sort_by(|a, b| match a.name.cmp(&b.name) {
+            Ordering::Equal => version_desc(&a.version, &b.version),
+            other => other,
+        });
+
+        println!("Runtime: {runtime}\nPlatform: {platform}");
+        if rows.is_empty() {
+            println!(
+                "\nNo plugins {} for this runtime/platform.",
+                if self.all {
+                    "(including missing entries)"
+                } else {
+                    "found"
+                }
+            );
+            return Ok(());
+        }
+        let name_w = 28usize;
+        let ver_w = 12usize;
+        println!(
+            "\n{:<name_w$} {:<ver_w$} STATUS",
+            "PLUGIN",
+            "VERSION",
+            name_w = name_w,
+            ver_w = ver_w
+        );
+        println!(
+            "{} {} {}",
+            "-".repeat(name_w),
+            "-".repeat(ver_w),
+            "-".repeat(40)
+        );
+        for r in rows {
+            println!(
+                "{:<name_w$} {:<ver_w$} {}",
+                r.name,
+                r.version,
+                r.status,
+                name_w = name_w,
+                ver_w = ver_w,
+            );
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+struct Row {
+    name: String,
+    version: String,
+    status: String,
+}
+
+fn version_desc(a: &str, b: &str) -> Ordering {
+    match (semver::Version::parse(a), semver::Version::parse(b)) {
+        (Ok(va), Ok(vb)) => vb.cmp(&va),
+        _ => b.cmp(a),
+    }
+}
+
+fn order_plugins(a: &str, b: &str, cuda: bool, noavx: bool) -> Ordering {
+    let rank = |name: &str| -> i32 {
+        if cuda && name.contains("ggml-cuda") {
+            return 0;
+        }
+        if noavx && name.contains("ggml-noavx") {
+            return 1;
+        }
+        if name.contains("ggml") {
+            return 2;
+        }
+        3
+    };
+    rank(a).cmp(&rank(b)).then(a.cmp(b))
+}
+
+async fn head_ok(url: &str) -> bool {
+    let client = reqwest::Client::new();
+    if let Ok(resp) = client.head(url).send().await {
+        if resp.status().is_success() {
+            return true;
+        }
+    }
+    if let Ok(resp) = client.get(url).send().await {
+        return resp.status().is_success();
+    }
+    false
+}
+
+#[derive(Debug, Clone)]
+struct AssetInfo {
+    plugin: String,
+    version: String,
+    platform: String,
+}
+
+async fn fetch_release_assets(tag: &str) -> Result<Vec<AssetInfo>, ()> {
+    let url = format!("{GH_RELEASE_TAG_API}/{tag}");
+    let client = reqwest::Client::new();
+    let resp = client
+        .get(&url)
+        .header("User-Agent", UA)
+        .send()
+        .await
+        .map_err(|_| ())?;
+    if !resp.status().is_success() {
+        return Err(());
+    }
+    let text = resp.text().await.map_err(|_| ())?;
+    let v: Value = serde_json::from_str(&text).map_err(|_| ())?;
+    let mut out = Vec::new();
+    if let Some(arr) = v.get("assets").and_then(|a| a.as_array()) {
+        for a in arr {
+            let name = a.get("name").and_then(|s| s.as_str()).unwrap_or("");
+            if !name.starts_with(ASSET_PREFIX) {
+                continue;
+            }
+            if let Some(info) = parse_asset_name(name, tag) {
+                out.push(AssetInfo {
+                    plugin: info.0,
+                    version: info.1,
+                    platform: info.2,
+                });
+            }
+        }
+    }
+    Ok(out)
+}
+
+fn parse_asset_name(name: &str, tag: &str) -> Option<(String, String, String)> {
+    let rest = name.strip_prefix(ASSET_PREFIX)?;
+    let needle = format!("-{tag}-");
+    if let Some(idx) = rest.find(&needle) {
+        let plugin = &rest[..idx];
+        let plat_with_ext = &rest[idx + needle.len()..];
+        let platform = plat_with_ext
+            .strip_suffix(TAR_GZ)
+            .or_else(|| plat_with_ext.strip_suffix(ZIP))
+            .unwrap_or(plat_with_ext);
+        return Some((plugin.to_string(), tag.to_string(), platform.to_string()));
+    }
+    None
+}
+
+pub fn platform_fallbacks(primary: &str, runtime: &str) -> Vec<String> {
+    let rt_ge_015 = runtime_ge_015(runtime);
+    let mut out = vec![primary.to_string()];
+    if primary.starts_with(UBUNTU20_PREFIX) {
+        if rt_ge_015 {
+            out.push(primary.replacen(UBUNTU20_PREFIX, MANYLINUX_2_28_PREFIX, 1));
+        } else {
+            out.push(primary.replacen(UBUNTU20_PREFIX, MANYLINUX2014_PREFIX, 1));
+        }
+    } else if primary.starts_with(UBUNTU22_PREFIX) {
+        out.push(primary.replacen(UBUNTU22_PREFIX, MANYLINUX_2_28_PREFIX, 1));
+    } else if primary.starts_with(MANYLINUX2014_PREFIX) && rt_ge_015 {
+        out.push(primary.replacen(MANYLINUX2014_PREFIX, MANYLINUX_2_28_PREFIX, 1));
+    }
+    out.sort();
+    out.dedup();
+    out
+}

--- a/src/commands/plugin/mod.rs
+++ b/src/commands/plugin/mod.rs
@@ -1,10 +1,16 @@
 mod install;
+pub mod list;
 mod remove;
+mod specs;
 mod version;
 
+use crate::cli::{CommandContext, CommandExecutor};
+use crate::prelude::*;
 use clap::{Parser, Subcommand};
 use install::PluginInstallArgs;
+use list::PluginListArgs;
 use remove::PluginRemoveArgs;
+use specs::PluginSpecsArgs;
 
 #[derive(Debug, Parser)]
 pub struct PluginCli {
@@ -16,8 +22,20 @@ pub struct PluginCli {
 pub enum PluginCommands {
     /// Install the specified WasmEdge plugin(s)
     Install(PluginInstallArgs),
-    /// List all available WasmEdge plugins according to the installed WasmEdge runtime version
-    List,
+    /// List WasmEdge plugins available for the current runtime/platform (or all with --all)
+    List(PluginListArgs),
     /// Uninstall the specified WasmEdge plugin(s)
     Remove(PluginRemoveArgs),
+    /// Show detected system specs used for plugin compatibility and selection
+    Specs(PluginSpecsArgs),
+}
+
+impl CommandExecutor for PluginCli {
+    async fn execute(self, ctx: CommandContext) -> Result<()> {
+        match self.commands {
+            PluginCommands::List(args) => args.execute(ctx).await,
+            PluginCommands::Specs(args) => args.execute(ctx).await,
+            _ => Err(Error::Unknown),
+        }
+    }
 }

--- a/src/commands/plugin/specs.rs
+++ b/src/commands/plugin/specs.rs
@@ -1,0 +1,16 @@
+use crate::cli::{CommandContext, CommandExecutor};
+use crate::prelude::*;
+use crate::system;
+use clap::Args;
+
+#[derive(Debug, Args)]
+pub struct PluginSpecsArgs {}
+
+impl CommandExecutor for PluginSpecsArgs {
+    async fn execute(self, _ctx: CommandContext) -> Result<()> {
+        let spec = system::detect();
+        let json = serde_json::to_string_pretty(&spec).map_err(|_| Error::Unknown)?;
+        println!("{json}");
+        Ok(())
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -68,6 +68,14 @@ pub enum Error {
         source: std::io::Error,
     },
 
+    #[snafu(display("Unsupported platform: os={os} arch={arch}"))]
+    UnsupportedPlatform { os: String, arch: String },
+
+    #[snafu(display(
+        "WasmEdge runtime not found on PATH; please install WasmEdge or ensure PATH is set"
+    ))]
+    RuntimeNotFound,
+
     #[default]
     #[snafu(display("Unknown error occurred"))]
     Unknown,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,4 +5,5 @@ pub mod error;
 pub mod fs;
 pub mod prelude;
 pub mod shell_utils; // This should now point to the directory
-mod target;
+pub mod system;
+pub mod target;

--- a/src/system/cpu.rs
+++ b/src/system/cpu.rs
@@ -1,0 +1,300 @@
+use crate::system::spec::{CpuClass, CpuFeature, CpuSpec};
+use crate::target::TargetArch;
+use std::collections::HashSet;
+
+#[cfg(unix)]
+use std::fs;
+#[cfg(unix)]
+use std::process::Command;
+
+#[cfg(windows)]
+use raw_cpuid::CpuId;
+#[cfg(windows)]
+use sysinfo::{CpuRefreshKind, RefreshKind, System};
+
+type ProcCpuInfo = (
+    Option<String>,      // vendor
+    Option<String>,      // model
+    Option<u32>,         // physical cores (sockets)
+    Option<u32>,         // logical cores (cpus)
+    HashSet<CpuFeature>, // feature flags
+);
+
+pub fn detect_cpu() -> (CpuSpec, Vec<String>, Vec<String>) {
+    #[cfg(unix)]
+    {
+        let notes = Vec::new();
+        let mut errors = Vec::new();
+
+        let arch = TargetArch::default();
+
+        let mut vendor = None;
+        let mut model = None;
+        let mut cores_physical = None;
+        let mut cores_logical = None;
+        let mut features: HashSet<CpuFeature> = HashSet::new();
+
+        if let Ok((v, m, phys, logi, flags)) = parse_proc_cpuinfo() {
+            vendor = v;
+            model = m;
+            cores_physical = phys;
+            cores_logical = logi;
+            features.extend(flags);
+        } else if let Ok((phys, logi)) = parse_lscpu() {
+            cores_physical = phys;
+            cores_logical = logi;
+        } else {
+            errors.push("cpu: unable to parse /proc/cpuinfo or lscpu".to_string());
+        }
+
+        let class = classify(&arch, &features);
+
+        let cpu = CpuSpec {
+            arch,
+            vendor,
+            model,
+            cores_physical,
+            cores_logical,
+            features,
+            class,
+        };
+
+        (cpu, notes, errors)
+    }
+
+    #[cfg(windows)]
+    {
+        let notes = Vec::new();
+        let errors = Vec::new();
+        let arch = TargetArch::default();
+
+        let cpuid = CpuId::new();
+        let vendor = cpuid.get_vendor_info().map(|v| v.as_str().to_string());
+        let model = cpuid
+            .get_processor_brand_string()
+            .map(|s| s.as_str().trim().to_string());
+
+        let sys =
+            System::new_with_specifics(RefreshKind::new().with_cpu(CpuRefreshKind::everything()));
+        let cores_logical = Some(sys.cpus().len() as u32);
+        let cores_physical = None;
+
+        let mut features: HashSet<CpuFeature> = HashSet::new();
+        if let Some(feat) = cpuid.get_feature_info() {
+            if feat.has_sse2() {
+                features.insert(CpuFeature::SSE2);
+            }
+            if feat.has_sse41() {
+                features.insert(CpuFeature::SSE4_1);
+            }
+            if feat.has_sse42() {
+                features.insert(CpuFeature::SSE4_2);
+            }
+            if feat.has_aesni() {
+                features.insert(CpuFeature::AESNI);
+            }
+            if feat.has_popcnt() {
+                features.insert(CpuFeature::POPCNT);
+            }
+        }
+        if let Some(ext) = cpuid.get_extended_feature_info() {
+            if ext.has_avx2() {
+                features.insert(CpuFeature::AVX2);
+            }
+            if ext.has_bmi1() {
+                features.insert(CpuFeature::BMI1);
+            }
+            if ext.has_bmi2() {
+                features.insert(CpuFeature::BMI2);
+            }
+        }
+        if let Some(info) = cpuid.get_feature_info() {
+            if info.has_avx() {
+                features.insert(CpuFeature::AVX);
+            }
+        }
+        if let Some(leaf7) = cpuid.get_extended_feature_info() {
+            if leaf7.has_avx512f() {
+                features.insert(CpuFeature::AVX512);
+            }
+        }
+        if cpuid
+            .get_feature_info()
+            .map(|f| f.has_fma())
+            .unwrap_or(false)
+        {
+            features.insert(CpuFeature::FMA);
+        }
+
+        let class = classify(&arch, &features);
+        let cpu = CpuSpec {
+            arch,
+            vendor,
+            model,
+            cores_physical,
+            cores_logical,
+            features,
+            class,
+        };
+        (cpu, notes, errors)
+    }
+}
+
+#[cfg(unix)]
+fn parse_proc_cpuinfo() -> Result<ProcCpuInfo, String> {
+    let content = fs::read_to_string("/proc/cpuinfo").map_err(|e| e.to_string())?;
+    let mut vendor: Option<String> = None;
+    let mut model: Option<String> = None;
+    let mut logical_count: u32 = 0;
+    let mut physical_ids: HashSet<String> = HashSet::new();
+    let mut flags_set: HashSet<CpuFeature> = HashSet::new();
+
+    for block in content.split("\n\n") {
+        if block.trim().is_empty() {
+            continue;
+        }
+        logical_count += 1;
+        for line in block.lines() {
+            if let Some((k, v)) = line.split_once(':') {
+                let key = k.trim();
+                let val = v.trim();
+                match key {
+                    "vendor_id" | "CPU implementer" => {
+                        if vendor.is_none() {
+                            vendor = Some(val.to_string());
+                        }
+                    }
+                    "model name" | "Hardware" => {
+                        if model.is_none() {
+                            model = Some(val.to_string());
+                        }
+                    }
+                    "physical id" => {
+                        physical_ids.insert(val.to_string());
+                    }
+                    "flags" | "Features" => {
+                        flags_set.extend(parse_flags(val));
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+
+    let phys = if !physical_ids.is_empty() {
+        Some(physical_ids.len() as u32)
+    } else {
+        None
+    };
+    let logi = if logical_count > 0 {
+        Some(logical_count)
+    } else {
+        None
+    };
+    Ok((vendor, model, phys, logi, flags_set))
+}
+
+#[cfg(unix)]
+fn parse_lscpu() -> Result<(Option<u32>, Option<u32>), String> {
+    let out = Command::new("lscpu").output().map_err(|e| e.to_string())?;
+    if !out.status.success() {
+        return Err("lscpu failed".into());
+    }
+    let s = String::from_utf8_lossy(&out.stdout);
+    let mut phys = None;
+    let mut logi = None;
+    for line in s.lines() {
+        if let Some((k, v)) = line.split_once(':') {
+            let k = k.trim().to_lowercase();
+            let v = v.trim();
+            if k == "socket(s)" || k == "sockets" {
+                phys = v.parse().ok();
+            }
+            if k == "cpu(s)" {
+                logi = v.parse().ok();
+            }
+        }
+    }
+    Ok((phys, logi))
+}
+
+pub fn parse_flags(s: &str) -> HashSet<CpuFeature> {
+    let mut set = HashSet::new();
+    for f in s.split_whitespace() {
+        match f.to_lowercase().as_str() {
+            // x86
+            "sse2" => {
+                set.insert(CpuFeature::SSE2);
+            }
+            "sse4_1" => {
+                set.insert(CpuFeature::SSE4_1);
+            }
+            "sse4_2" => {
+                set.insert(CpuFeature::SSE4_2);
+            }
+            "avx" => {
+                set.insert(CpuFeature::AVX);
+            }
+            "avx2" => {
+                set.insert(CpuFeature::AVX2);
+            }
+            f if f.starts_with("avx512") => {
+                set.insert(CpuFeature::AVX512);
+            }
+            "fma" => {
+                set.insert(CpuFeature::FMA);
+            }
+            "bmi1" => {
+                set.insert(CpuFeature::BMI1);
+            }
+            "bmi2" => {
+                set.insert(CpuFeature::BMI2);
+            }
+            "aes" | "aesni" => {
+                set.insert(CpuFeature::AESNI);
+            }
+            "popcnt" => {
+                set.insert(CpuFeature::POPCNT);
+            }
+            // arm
+            "neon" | "asimd" => {
+                set.insert(CpuFeature::NEON);
+            }
+            "sve" => {
+                set.insert(CpuFeature::SVE);
+            }
+            "sve2" => {
+                set.insert(CpuFeature::SVE2);
+            }
+            _ => {}
+        }
+    }
+    set
+}
+
+pub fn classify(arch: &TargetArch, features: &HashSet<CpuFeature>) -> CpuClass {
+    match arch {
+        TargetArch::X86_64 => {
+            if features.contains(&CpuFeature::AVX512) {
+                CpuClass::Avx512
+            } else if features.contains(&CpuFeature::AVX2) {
+                CpuClass::Avx2
+            } else if features.contains(&CpuFeature::AVX) {
+                CpuClass::Avx
+            } else {
+                CpuClass::NoAvx
+            }
+        }
+        TargetArch::Aarch64 => {
+            if features.contains(&CpuFeature::SVE2) {
+                CpuClass::Sve2
+            } else if features.contains(&CpuFeature::SVE) {
+                CpuClass::Sve
+            } else if features.contains(&CpuFeature::NEON) {
+                CpuClass::Neon
+            } else {
+                CpuClass::Generic
+            }
+        }
+    }
+}

--- a/src/system/detector.rs
+++ b/src/system/detector.rs
@@ -1,0 +1,58 @@
+use crate::system::cpu::detect_cpu;
+use crate::system::gpu::detect_gpu;
+use crate::system::os::detect_os;
+use crate::system::spec::{LibcKind, SystemSpec};
+use crate::system::toolchain::detect_toolchain;
+use crate::target::TargetArch;
+
+pub fn detect() -> SystemSpec {
+    let (os, mut notes, mut errors) = detect_os();
+    let (cpu, n2, e2) = detect_cpu();
+    let (gpus, accelerators, n3, e3) = detect_gpu();
+    let (toolchain, n4, e4) = detect_toolchain(os.libc.kind, os.libc.version.clone());
+
+    notes.extend(n2);
+    notes.extend(n3);
+    notes.extend(n4);
+
+    errors.extend(e2);
+    errors.extend(e3);
+    errors.extend(e4);
+
+    let target_triple = compute_target_triple(os.os_type, os.arch, os.libc.kind);
+
+    SystemSpec {
+        os,
+        cpu,
+        gpus,
+        accelerators,
+        toolchain,
+        target_triple,
+        notes,
+        detection_errors: errors,
+    }
+}
+
+fn compute_target_triple(os: crate::target::TargetOS, arch: TargetArch, libc: LibcKind) -> String {
+    let arch_str = match arch {
+        TargetArch::X86_64 => "x86_64",
+        TargetArch::Aarch64 => "aarch64",
+    };
+
+    match os {
+        crate::target::TargetOS::Linux | crate::target::TargetOS::Ubuntu => {
+            let abi = match libc {
+                LibcKind::Musl => "musl",
+                _ => "gnu",
+            };
+            format!("{arch_str}-unknown-linux-{abi}")
+        }
+        crate::target::TargetOS::Darwin => {
+            format!("{arch_str}-apple-darwin")
+        }
+        crate::target::TargetOS::Windows => {
+            // MSVC by default
+            format!("{arch_str}-pc-windows-msvc")
+        }
+    }
+}

--- a/src/system/gpu.rs
+++ b/src/system/gpu.rs
@@ -1,0 +1,397 @@
+use crate::system::spec::{
+    AcceleratorSupport, CudaSpec, GpuSpec, GpuVendor, OpenClDeviceSpec, RocmSpec,
+};
+use std::path::PathBuf;
+
+#[cfg(unix)]
+use std::process::Command;
+
+#[cfg(windows)]
+use nvml_wrapper::Nvml;
+#[cfg(all(windows, feature = "opencl"))]
+use opencl3::platform::{get_platforms, Platform};
+#[cfg(windows)]
+use serde::Deserialize;
+#[cfg(windows)]
+use wmi::{COMLibrary, WMIConnection};
+
+#[cfg(windows)]
+#[derive(Deserialize)]
+#[serde(rename = "Win32_VideoController")]
+struct VideoController {
+    #[serde(rename = "Name")]
+    name: Option<String>,
+    #[serde(rename = "AdapterRAM")]
+    adapter_ram: Option<i64>,
+}
+
+pub fn detect_gpu() -> (Vec<GpuSpec>, AcceleratorSupport, Vec<String>, Vec<String>) {
+    #[cfg(unix)]
+    let notes = Vec::new();
+    #[cfg(unix)]
+    let mut errors = Vec::new();
+    #[cfg(windows)]
+    let notes = Vec::new();
+    #[cfg(windows)]
+    let mut errors = Vec::new();
+
+    let nvidia_smi = which("nvidia-smi");
+    #[cfg(unix)]
+    let rocminfo = which("rocminfo");
+    let clinfo = which("clinfo");
+    let vulkaninfo = which("vulkaninfo");
+
+    let mut gpus: Vec<GpuSpec> = Vec::new();
+
+    #[cfg(unix)]
+    {
+        // NVIDIA via nvidia-smi
+        if let Some(path) = nvidia_smi.clone() {
+            match query_nvidia_smi(&path) {
+                Ok(mut list) => gpus.append(&mut list),
+                Err(e) => errors.push(format!("nvidia-smi: {e}")),
+            }
+        }
+
+        // ROCm via rocminfo
+        if let Some(path) = rocminfo.clone() {
+            match query_rocminfo(&path) {
+                Ok(mut list) => gpus.append(&mut list),
+                Err(e) => errors.push(format!("rocminfo: {e}")),
+            }
+        }
+    }
+
+    #[cfg(unix)]
+    {
+        // OpenCL summary via clinfo
+        let mut opencl_available = false;
+        if let Some(path) = clinfo.clone() {
+            match query_clinfo_minimal(&path) {
+                Ok(mut cl_list) => {
+                    if !cl_list.is_empty() {
+                        opencl_available = true;
+                        for cl_spec in cl_list.drain(..) {
+                            let mut merged = false;
+                            for g in &mut gpus {
+                                if g.opencl.is_none() && g.vendor == cl_spec.vendor {
+                                    g.opencl = cl_spec.opencl.clone();
+                                    merged = true;
+                                    break;
+                                }
+                            }
+                            if !merged {
+                                gpus.push(cl_spec);
+                            }
+                        }
+                    }
+                }
+                Err(e) => {
+                    errors.push(format!("clinfo: {e}"));
+                }
+            }
+        }
+
+        let accelerators = AcceleratorSupport {
+            cuda_available: nvidia_smi.is_some(),
+            rocm_available: rocminfo.is_some(),
+            opencl_available,
+            vulkan_available: vulkaninfo.is_some(),
+        };
+        return (gpus, accelerators, notes, errors);
+    }
+
+    #[cfg(windows)]
+    {
+        // Windows path: prefer NVML, then OpenCL, then WMI fallback
+        // NVML
+        match Nvml::init() {
+            Ok(nvml) => {
+                if let Ok(count) = nvml.device_count() {
+                    for i in 0..count {
+                        if let Ok(dev) = nvml.device_by_index(i) {
+                            let name = dev.name().ok().map(|s| s.to_string());
+                            let mem = dev
+                                .memory_info()
+                                .ok()
+                                .map(|m| (m.total / (1024 * 1024)) as u32);
+                            let driver = nvml.sys_driver_version().ok().map(|s| s.to_string());
+                            let uuid = dev.uuid().ok().map(|s| s.to_string());
+                            let cuda = Some(CudaSpec {
+                                driver_version: driver,
+                                runtime_version: None,
+                                compute_capability: None,
+                                device_uuid: uuid,
+                            });
+                            gpus.push(GpuSpec {
+                                vendor: GpuVendor::Nvidia,
+                                model: name,
+                                vram_mb: mem,
+                                bus: None,
+                                cuda,
+                                rocm: None,
+                                opencl: None,
+                            });
+                        }
+                    }
+                }
+            }
+            Err(e) => {
+                errors.push(format!("nvml init failed: {e}"));
+            }
+        }
+
+        // OpenCL via opencl3 (optional feature)
+        #[cfg(feature = "opencl")]
+        let mut opencl_available = false;
+        #[cfg(not(feature = "opencl"))]
+        let mut opencl_available = false;
+        #[cfg(feature = "opencl")]
+        {
+            if let Ok(platforms) = get_platforms() {
+                if !platforms.is_empty() {
+                    opencl_available = true;
+                    if gpus.is_empty() {
+                        // Add minimal OpenCL entry for first platform
+                        let p = platforms[0];
+                        let plat = Platform::new(p.into());
+                        let pname = plat.name().ok().unwrap_or_default();
+                        let pvend = plat.vendor().ok().unwrap_or_default();
+                        let pver = plat.version().ok().unwrap_or_default();
+                        gpus.push(GpuSpec {
+                            vendor: vendor_from_str(&pvend),
+                            model: None,
+                            vram_mb: None,
+                            bus: None,
+                            cuda: None,
+                            rocm: None,
+                            opencl: Some(OpenClDeviceSpec {
+                                platform: pname,
+                                vendor: pvend,
+                                version: pver,
+                            }),
+                        });
+                    }
+                }
+            }
+        }
+        // WMI fallback if no GPUs found
+        if gpus.is_empty() {
+            if let Ok(com) = COMLibrary::new() {
+                if let Ok(wmi_con) = WMIConnection::new(com.into()) {
+                    if let Ok(results) = wmi_con.query::<VideoController>() {
+                        for v in results {
+                            let name: Option<String> = v.name;
+                            let ram_mb: Option<u32> =
+                                v.adapter_ram.map(|n| (n as u64 / (1024 * 1024)) as u32);
+                            gpus.push(GpuSpec {
+                                vendor: name
+                                    .as_ref()
+                                    .map(|s| vendor_from_str(s))
+                                    .unwrap_or(GpuVendor::Other),
+                                model: name,
+                                vram_mb: ram_mb,
+                                bus: None,
+                                cuda: None,
+                                rocm: None,
+                                opencl: None,
+                            });
+                        }
+                    }
+                }
+            }
+        }
+
+        let accelerators = AcceleratorSupport {
+            cuda_available: !gpus.is_empty()
+                && gpus
+                    .iter()
+                    .any(|g| matches!(g.vendor, GpuVendor::Nvidia) && g.cuda.is_some()),
+            rocm_available: false,
+            opencl_available,
+            vulkan_available: vulkaninfo.is_some(),
+        };
+        return (gpus, accelerators, notes, errors);
+    }
+
+    #[allow(unreachable_code)]
+    (
+        gpus,
+        AcceleratorSupport {
+            cuda_available: false,
+            rocm_available: false,
+            opencl_available: false,
+            vulkan_available: false,
+        },
+        Vec::new(),
+        Vec::new(),
+    )
+}
+
+#[cfg(windows)]
+fn vendor_from_str(s: &str) -> GpuVendor {
+    let l = s.to_lowercase();
+    if l.contains("nvidia") {
+        GpuVendor::Nvidia
+    } else if l.contains("advanced micro devices") || l.contains("amd") {
+        GpuVendor::AMD
+    } else if l.contains("intel") {
+        GpuVendor::Intel
+    } else {
+        GpuVendor::Other
+    }
+}
+
+fn which(bin: &str) -> Option<PathBuf> {
+    std::env::var_os("PATH").and_then(|paths| {
+        std::env::split_paths(&paths).find_map(|p| {
+            let candidate = p.join(bin);
+            if candidate.exists() {
+                Some(candidate)
+            } else {
+                None
+            }
+        })
+    })
+}
+
+#[cfg(unix)]
+fn query_nvidia_smi(path: &PathBuf) -> Result<Vec<GpuSpec>, String> {
+    let out = Command::new(path)
+        .args([
+            "--query-gpu=name,uuid,memory.total,driver_version,compute_cap",
+            "--format=csv,noheader,nounits",
+        ])
+        .output()
+        .map_err(|e| e.to_string())?;
+    if !out.status.success() {
+        return Err("nvidia-smi failed".into());
+    }
+    let s = String::from_utf8_lossy(&out.stdout);
+    let mut list = Vec::new();
+    for line in s.lines() {
+        let cols: Vec<_> = line.split(',').map(|c| c.trim()).collect();
+        if cols.len() < 5 {
+            continue;
+        }
+        let model = Some(cols[0].to_string());
+        let device_uuid = Some(cols[1].to_string());
+        let vram_mb = cols[2].parse::<u32>().ok();
+        let driver_version = Some(cols[3].to_string());
+        let compute_capability = Some(cols[4].to_string());
+        let cuda = Some(CudaSpec {
+            driver_version,
+            runtime_version: None,
+            compute_capability,
+            device_uuid,
+        });
+        list.push(GpuSpec {
+            vendor: GpuVendor::Nvidia,
+            model,
+            vram_mb,
+            bus: None,
+            cuda,
+            rocm: None,
+            opencl: None,
+        });
+    }
+    Ok(list)
+}
+
+#[cfg(unix)]
+fn query_rocminfo(path: &PathBuf) -> Result<Vec<GpuSpec>, String> {
+    let out = Command::new(path).output().map_err(|e| e.to_string())?;
+    if !out.status.success() {
+        return Err("rocminfo failed".into());
+    }
+    let s = String::from_utf8_lossy(&out.stdout);
+    let mut list = Vec::new();
+    for line in s.lines() {
+        if let Some(idx) = line.find("gfx") {
+            let token = &line[idx..];
+            let gfx = token.split_whitespace().next().unwrap_or("").to_string();
+            list.push(GpuSpec {
+                vendor: GpuVendor::AMD,
+                model: None,
+                vram_mb: None,
+                bus: None,
+                cuda: None,
+                rocm: Some(RocmSpec {
+                    rocm_version: None,
+                    gfx_arch: Some(gfx),
+                }),
+                opencl: None,
+            });
+            break;
+        }
+    }
+    Ok(list)
+}
+
+#[cfg(unix)]
+fn query_clinfo_minimal(path: &PathBuf) -> Result<Vec<GpuSpec>, String> {
+    let out = Command::new(path).output().map_err(|e| e.to_string())?;
+    if !out.status.success() {
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        return Err(format!("clinfo failed: {}", stderr.trim()));
+    }
+    let s = String::from_utf8_lossy(&out.stdout);
+    let mut list = Vec::new();
+    let mut platform = None;
+    let mut vendor = None;
+    let mut version = None;
+    for line in s.lines() {
+        let l = line.trim();
+
+        let take_val = |key: &str, target: &mut Option<String>| {
+            if l.starts_with(key) && target.is_none() {
+                let mut rest = &l[key.len()..];
+                rest = rest.trim_start();
+                if rest.starts_with(':') {
+                    rest = rest[1..].trim_start();
+                }
+                if !rest.is_empty() {
+                    *target = Some(rest.to_string());
+                }
+            }
+        };
+
+        take_val("Platform Name", &mut platform);
+        take_val("Platform Vendor", &mut vendor);
+        take_val("Platform Version", &mut version);
+
+        if platform.is_some() && vendor.is_some() && version.is_some() {
+            break;
+        }
+    }
+
+    if let (Some(p), Some(v), Some(ver)) = (platform, vendor, version) {
+        list.push(GpuSpec {
+            vendor: if v.to_lowercase().contains("nvidia") {
+                GpuVendor::Nvidia
+            } else if v.to_lowercase().contains("advanced micro devices")
+                || v.to_lowercase().contains("amd")
+            {
+                GpuVendor::AMD
+            } else if v.to_lowercase().contains("intel") {
+                GpuVendor::Intel
+            } else {
+                GpuVendor::Other
+            },
+            model: None,
+            vram_mb: None,
+            bus: None,
+            cuda: None,
+            rocm: None,
+            opencl: Some(OpenClDeviceSpec {
+                platform: p,
+                vendor: v,
+                version: ver,
+            }),
+        });
+    }
+    if list.is_empty() {
+        return Err("no OpenCL platforms detected via clinfo".into());
+    }
+    Ok(list)
+}

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -1,0 +1,13 @@
+pub mod cpu;
+pub mod detector;
+pub mod gpu;
+pub mod os;
+pub mod plugins;
+pub mod spec;
+pub mod toolchain;
+
+pub use detector::detect;
+pub use spec::{
+    AcceleratorSupport, CpuClass, CpuFeature, CpuSpec, CudaSpec, GpuSpec, GpuVendor, LibcKind,
+    LibcSpec, OpenClDeviceSpec, OsSpec, RocmSpec, SystemSpec, ToolchainSpec,
+};

--- a/src/system/os.rs
+++ b/src/system/os.rs
@@ -1,0 +1,160 @@
+use crate::system::spec::{LibcKind, LibcSpec, OsSpec};
+use crate::target::{TargetArch, TargetOS};
+use std::fs;
+#[cfg(unix)]
+use std::process::Command;
+
+pub fn detect_os() -> (OsSpec, Vec<String>, Vec<String>) {
+    #[cfg(unix)]
+    {
+        detect_os_unix()
+    }
+    #[cfg(windows)]
+    {
+        detect_os_windows()
+    }
+}
+
+#[cfg(unix)]
+fn detect_os_unix() -> (OsSpec, Vec<String>, Vec<String>) {
+    let notes = Vec::new();
+    let mut errors = Vec::new();
+
+    let os_type = TargetOS::default();
+    let arch = TargetArch::default();
+
+    let (distro, version) = read_os_release().unwrap_or_else(|e| {
+        errors.push(format!("os-release: {e}"));
+        (None, None)
+    });
+
+    let kernel = uname_kernel().unwrap_or_else(|e| {
+        errors.push(format!("uname: {e}"));
+        None
+    });
+
+    let libc = detect_libc().unwrap_or_else(|e| {
+        errors.push(format!("libc: {e}"));
+        LibcSpec {
+            kind: LibcKind::Unknown,
+            version: None,
+        }
+    });
+
+    let os = OsSpec {
+        os_type,
+        arch,
+        distro,
+        version,
+        kernel,
+        libc,
+    };
+    (os, notes, errors)
+}
+
+#[cfg(windows)]
+fn detect_os_windows() -> (OsSpec, Vec<String>, Vec<String>) {
+    let notes = Vec::new();
+    let errors = Vec::new();
+
+    let os_type = TargetOS::default();
+    let arch = TargetArch::default();
+
+    let distro = Some("Windows".to_string());
+    let version = None;
+    let kernel = None;
+    let libc = LibcSpec {
+        kind: LibcKind::Unknown,
+        version: None,
+    };
+
+    let os = OsSpec {
+        os_type,
+        arch,
+        distro,
+        version,
+        kernel,
+        libc,
+    };
+    (os, notes, errors)
+}
+
+#[cfg(unix)]
+fn read_os_release() -> Result<(Option<String>, Option<String>), String> {
+    let content = fs::read_to_string("/etc/os-release").map_err(|e| e.to_string())?;
+    let mut name: Option<String> = None;
+    let mut version: Option<String> = None;
+    for line in content.lines() {
+        let line = line.trim();
+        if line.starts_with('#') || line.is_empty() {
+            continue;
+        }
+        if let Some((k, v)) = line.split_once('=') {
+            let v = v.trim_matches('"');
+            if (k == "NAME" || k == "ID") && name.is_none() {
+                name = Some(v.to_string());
+            }
+            if k == "VERSION_ID" {
+                version = Some(v.to_string());
+            }
+        }
+    }
+    Ok((name, version))
+}
+
+#[cfg(unix)]
+fn uname_kernel() -> Result<Option<String>, String> {
+    let out = Command::new("uname")
+        .arg("-srm")
+        .output()
+        .map_err(|e| e.to_string())?;
+    if out.status.success() {
+        Ok(Some(
+            String::from_utf8_lossy(&out.stdout).trim().to_string(),
+        ))
+    } else {
+        Ok(None)
+    }
+}
+
+#[cfg(unix)]
+fn detect_libc() -> Result<LibcSpec, String> {
+    let out = Command::new("ldd")
+        .arg("--version")
+        .output()
+        .map_err(|e| e.to_string())?;
+    if !out.status.success() {
+        return Ok(LibcSpec {
+            kind: LibcKind::Unknown,
+            version: None,
+        });
+    }
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let s = stdout.to_lowercase();
+    if s.contains("musl") {
+        let ver = stdout
+            .lines()
+            .next()
+            .and_then(|l| l.split_whitespace().last())
+            .map(|s| s.to_string());
+        Ok(LibcSpec {
+            kind: LibcKind::Musl,
+            version: ver,
+        })
+    } else if s.contains("glibc") || s.contains("gnu libc") || s.contains("gnu c library") {
+        let ver: Option<String> = stdout
+            .lines()
+            .next()
+            .and_then(|l| l.split_whitespace().last())
+            .map(|s| s.to_string());
+        Ok(LibcSpec {
+            kind: LibcKind::Glibc,
+            version: ver,
+        })
+    } else {
+        Ok(LibcSpec {
+            kind: LibcKind::Unknown,
+            version: None,
+        })
+    }
+}

--- a/src/system/plugins.rs
+++ b/src/system/plugins.rs
@@ -1,0 +1,40 @@
+use crate::error::{Error, Result};
+use crate::system::spec::{LibcKind, OsSpec};
+use crate::target::{TargetArch, TargetOS};
+
+pub fn platform_key_from_specs(os: &OsSpec) -> Result<String> {
+    let arch_str = match os.arch {
+        TargetArch::X86_64 => "x86_64",
+        TargetArch::Aarch64 => "aarch64",
+    };
+    match os.os_type {
+        TargetOS::Darwin => {
+            let a = if matches!(os.arch, TargetArch::Aarch64) {
+                "arm64"
+            } else {
+                arch_str
+            };
+            Ok(format!("darwin_{a}"))
+        }
+        TargetOS::Windows => Ok("windows_x86_64".to_string()),
+        TargetOS::Linux | TargetOS::Ubuntu => {
+            let distro = os.distro.as_deref().unwrap_or("").to_lowercase();
+            let version = os.version.as_deref().unwrap_or("");
+            if distro.contains("ubuntu") {
+                if version.starts_with("20.04") || version.starts_with("20") {
+                    return Ok(format!("ubuntu20_04_{arch_str}"));
+                }
+                if version.starts_with("22.04") || version.starts_with("22") {
+                    return Ok(format!("ubuntu22_04_{arch_str}"));
+                }
+            }
+            if matches!(os.libc.kind, LibcKind::Glibc) {
+                return Ok(format!("manylinux_2_28_{arch_str}"));
+            }
+            Err(Error::UnsupportedPlatform {
+                os: format!("{:?}", os.os_type),
+                arch: format!("{:?}", os.arch),
+            })
+        }
+    }
+}

--- a/src/system/spec.rs
+++ b/src/system/spec.rs
@@ -1,0 +1,143 @@
+use serde::Serialize;
+use std::collections::HashSet;
+use std::path::PathBuf;
+
+use crate::target::{TargetArch, TargetOS};
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SystemSpec {
+    pub os: OsSpec,
+    pub cpu: CpuSpec,
+    pub gpus: Vec<GpuSpec>,
+    pub accelerators: AcceleratorSupport,
+    pub toolchain: ToolchainSpec,
+    pub target_triple: String,
+    pub notes: Vec<String>,
+    pub detection_errors: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct OsSpec {
+    pub os_type: TargetOS,
+    pub arch: TargetArch,
+    pub distro: Option<String>,
+    pub version: Option<String>,
+    pub kernel: Option<String>,
+    pub libc: LibcSpec,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct LibcSpec {
+    pub kind: LibcKind,
+    pub version: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize)]
+pub enum LibcKind {
+    Glibc,
+    Musl,
+    Unknown,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CpuSpec {
+    pub arch: TargetArch,
+    pub vendor: Option<String>,
+    pub model: Option<String>,
+    pub cores_physical: Option<u32>,
+    pub cores_logical: Option<u32>,
+    pub features: HashSet<CpuFeature>,
+    pub class: CpuClass,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
+pub enum CpuFeature {
+    // x86
+    SSE2,
+    SSE4_1,
+    SSE4_2,
+    AVX,
+    AVX2,
+    AVX512,
+    FMA,
+    BMI1,
+    BMI2,
+    AESNI,
+    POPCNT,
+    // ARM
+    NEON,
+    SVE,
+    SVE2,
+}
+
+#[derive(Debug, Clone, Copy, Serialize)]
+pub enum CpuClass {
+    Avx512,
+    Avx2,
+    Avx,
+    NoAvx,
+    Neon,
+    NeonOnly,
+    Sve,
+    Sve2,
+    Generic,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct GpuSpec {
+    pub vendor: GpuVendor,
+    pub model: Option<String>,
+    pub vram_mb: Option<u32>,
+    pub bus: Option<String>,
+    pub cuda: Option<CudaSpec>,
+    pub rocm: Option<RocmSpec>,
+    pub opencl: Option<OpenClDeviceSpec>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+pub enum GpuVendor {
+    Nvidia,
+    AMD,
+    Intel,
+    Other,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CudaSpec {
+    pub driver_version: Option<String>,
+    pub runtime_version: Option<String>,
+    pub compute_capability: Option<String>,
+    pub device_uuid: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RocmSpec {
+    pub rocm_version: Option<String>,
+    pub gfx_arch: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct OpenClDeviceSpec {
+    pub platform: String,
+    pub vendor: String,
+    pub version: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct AcceleratorSupport {
+    pub cuda_available: bool,
+    pub rocm_available: bool,
+    pub opencl_available: bool,
+    pub vulkan_available: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ToolchainSpec {
+    pub nvidia_smi_path: Option<PathBuf>,
+    pub nvcc_path: Option<PathBuf>,
+    pub rocminfo_path: Option<PathBuf>,
+    pub clinfo_path: Option<PathBuf>,
+    pub vulkaninfo_path: Option<PathBuf>,
+    pub libc_kind: LibcKind,
+    pub libc_version: Option<String>,
+}

--- a/src/system/toolchain.rs
+++ b/src/system/toolchain.rs
@@ -1,0 +1,70 @@
+use crate::system::spec::{LibcKind, ToolchainSpec};
+use std::path::PathBuf;
+use std::process::Command;
+
+pub fn detect_toolchain(
+    libc_kind: LibcKind,
+    libc_version: Option<String>,
+) -> (ToolchainSpec, Vec<String>, Vec<String>) {
+    let notes = Vec::new();
+    let errors = Vec::new();
+
+    let nvidia_smi_path = which("nvidia-smi");
+    let nvcc_path = which("nvcc");
+    let rocminfo_path = which("rocminfo");
+    let clinfo_path = which("clinfo");
+    let vulkaninfo_path = which("vulkaninfo");
+
+    let toolchain = ToolchainSpec {
+        nvidia_smi_path,
+        nvcc_path,
+        rocminfo_path,
+        clinfo_path,
+        vulkaninfo_path,
+        libc_kind,
+        libc_version,
+    };
+
+    (toolchain, notes, errors)
+}
+
+fn which(bin: &str) -> Option<PathBuf> {
+    std::env::var_os("PATH").and_then(|paths| {
+        std::env::split_paths(&paths).find_map(|p| {
+            let candidate = p.join(bin);
+            if candidate.exists() {
+                Some(candidate)
+            } else {
+                None
+            }
+        })
+    })
+}
+
+pub fn get_installed_wasmedge_version() -> Result<String, String> {
+    let out = Command::new("wasmedge")
+        .arg("--version")
+        .output()
+        .map_err(|e| format!("failed to exec wasmedge: {e}"))?;
+    if !out.status.success() {
+        return Err("wasmedge --version exited with non-zero status".to_string());
+    }
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    // Heuristic parse: pick the first token that starts with a digit and contains at least one '.'
+    // e.g., "wasmedge version 0.15.0" -> 0.15.0
+    // also accept prerelease like 0.15.0-rc.1
+    for token in stdout.split_whitespace() {
+        if token
+            .chars()
+            .next()
+            .map(|c| c.is_ascii_digit())
+            .unwrap_or(false)
+            && token.contains('.')
+        {
+            let ver = token
+                .trim_end_matches(|c: char| !c.is_ascii_alphanumeric() && c != '.' && c != '-');
+            return Ok(ver.to_string());
+        }
+    }
+    Err(format!("unable to parse version from: {}", stdout.trim()))
+}

--- a/src/target.rs
+++ b/src/target.rs
@@ -1,6 +1,7 @@
 use clap::ValueEnum;
+use serde::Serialize;
 
-#[derive(Debug, Clone, ValueEnum)]
+#[derive(Debug, Clone, Copy, ValueEnum, Serialize)]
 pub enum TargetOS {
     Linux,
     Ubuntu,
@@ -65,27 +66,15 @@ fn get_ubuntu_version() -> Option<(u32, u32)> {
     None
 }
 
-#[derive(Debug, Clone, ValueEnum)]
+#[derive(Debug, Clone, Copy, ValueEnum, Serialize, Default)]
 pub enum TargetArch {
     /// aliases: [x86_64, amd64]
     #[value(name = "x86_64", alias("amd64"))]
+    #[cfg_attr(target_arch = "x86_64", default)]
     X86_64,
 
     /// aliases: [aarch64, arm64]
     #[value(alias("arm64"))]
+    #[cfg_attr(target_arch = "aarch64", default)]
     Aarch64,
-}
-
-impl Default for TargetArch {
-    fn default() -> Self {
-        cfg_if::cfg_if! {
-            if #[cfg(target_arch = "x86_64")] {
-                Self::X86_64
-            } else if #[cfg(target_arch = "aarch64")] {
-                Self::Aarch64
-            } else {
-                compile_error!("Unsupported target architecture: {}", std::env::consts::ARCH);
-            }
-        }
-    }
 }

--- a/tests/plugin-list-tests.rs
+++ b/tests/plugin-list-tests.rs
@@ -1,0 +1,100 @@
+use serde_json::Value;
+use wasmedgeup::{
+    api::runtime_ge_015,
+    commands::plugin::list::platform_fallbacks,
+    system::{self, plugins::platform_key_from_specs},
+};
+
+const ASSET_PREFIX: &str = "WasmEdge-plugin-";
+const GH_RELEASE_TAG_API: &str = "https://api.github.com/repos/WasmEdge/WasmEdge/releases/tags";
+
+#[test]
+fn test_runtime_ge_015_cases() {
+    assert!(!runtime_ge_015("0.14.2"));
+    assert!(runtime_ge_015("0.15.0"));
+    assert!(runtime_ge_015("0.15.1"));
+    assert!(runtime_ge_015("1.0.0"));
+    assert!(runtime_ge_015("not-a-version"));
+    assert!(runtime_ge_015(""));
+}
+
+#[test]
+fn test_platform_fallbacks_ubuntu20_old_runtime() {
+    let out = platform_fallbacks("ubuntu20_04_x86_64", "0.14.2");
+    assert!(out.contains(&"ubuntu20_04_x86_64".to_string()));
+    assert!(out.contains(&"manylinux2014_x86_64".to_string()));
+    assert!(!out.contains(&"manylinux_2_28_x86_64".to_string()));
+}
+
+#[test]
+fn test_platform_fallbacks_ubuntu20_new_runtime() {
+    let out = platform_fallbacks("ubuntu20_04_x86_64", "0.15.0");
+    assert!(out.contains(&"ubuntu20_04_x86_64".to_string()));
+    assert!(out.contains(&"manylinux_2_28_x86_64".to_string()));
+}
+
+#[test]
+fn test_platform_fallbacks_ubuntu22_any_runtime() {
+    let out = platform_fallbacks("ubuntu22_04_x86_64", "0.14.2");
+    assert!(out.contains(&"ubuntu22_04_x86_64".to_string()));
+    assert!(out.contains(&"manylinux_2_28_x86_64".to_string()));
+}
+
+#[test]
+fn test_platform_fallbacks_manylinux2014_with_new_runtime() {
+    let out = platform_fallbacks("manylinux2014_x86_64", "0.16.0");
+    assert!(out.contains(&"manylinux2014_x86_64".to_string()));
+    assert!(out.contains(&"manylinux_2_28_x86_64".to_string()));
+}
+
+#[tokio::test]
+async fn test_github_assets_list_contains_expected_platform() {
+    let spec = system::detect();
+    let platform = platform_key_from_specs(&spec.os).expect("platform key");
+    let runtime = match system::toolchain::get_installed_wasmedge_version() {
+        Ok(v) => v,
+        Err(_) => "0.15.0".to_string(),
+    };
+    let url = format!("{GH_RELEASE_TAG_API}/{runtime}");
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .get(&url)
+        .header("User-Agent", "wasmedgeup-tests")
+        .send()
+        .await;
+
+    let resp = match resp {
+        Ok(r) if r.status().is_success() => r,
+        _ => return,
+    };
+    let text = resp.text().await.unwrap_or_default();
+    let v: Value = match serde_json::from_str(&text) {
+        Ok(j) => j,
+        Err(_) => return,
+    };
+
+    let mut names: Vec<String> = Vec::new();
+    if let Some(arr) = v.get("assets").and_then(|a| a.as_array()) {
+        for a in arr {
+            if let Some(name) = a.get("name").and_then(|s| s.as_str()) {
+                if name.starts_with(ASSET_PREFIX) {
+                    names.push(name.to_string());
+                }
+            }
+        }
+    }
+
+    let candidates = platform_fallbacks(&platform, &runtime);
+    let mut matched = false;
+    for plat in &candidates {
+        if names.iter().any(|n| n.contains(plat)) {
+            matched = true;
+            break;
+        }
+    }
+    assert!(
+        matched || names.is_empty(),
+        "Either matched a platform asset, or release has no plugin assets at all"
+    );
+}

--- a/tests/system-tests.rs
+++ b/tests/system-tests.rs
@@ -1,0 +1,87 @@
+use wasmedgeup::system;
+use wasmedgeup::system::cpu::{classify, parse_flags};
+use wasmedgeup::system::plugins::platform_key_from_specs;
+use wasmedgeup::system::spec::{CpuClass, CpuFeature};
+use wasmedgeup::target::TargetArch;
+
+#[test]
+fn test_platform_key_detect_non_empty() {
+    let spec = system::detect();
+    let key = platform_key_from_specs(&spec.os).expect("platform key");
+    assert!(!key.is_empty());
+}
+
+#[test]
+fn test_platform_key_has_known_arch_suffix() {
+    let spec = system::detect();
+    let key = platform_key_from_specs(&spec.os).expect("platform key");
+    assert!(
+        key.ends_with("x86_64") || key.ends_with("aarch64") || key.ends_with("arm64"),
+        "unexpected platform key suffix: {key}"
+    );
+}
+
+#[test]
+fn test_platform_key_prefix_is_reasonable() {
+    let spec = system::detect();
+    let key = platform_key_from_specs(&spec.os).expect("platform key");
+    let ok_prefix = key.starts_with("ubuntu20_04_")
+        || key.starts_with("ubuntu22_04_")
+        || key.starts_with("manylinux2014_")
+        || key.starts_with("manylinux_2_28_")
+        || key.starts_with("darwin_")
+        || key.starts_with("windows_");
+    assert!(ok_prefix, "unexpected platform key prefix: {key}");
+}
+
+#[test]
+fn test_cpu_parse_flags_x86() {
+    let flags = parse_flags("sse2 sse4_1 sse4_2 avx avx2 avx512f fma bmi1 bmi2 aes popcnt");
+    assert!(flags.contains(&CpuFeature::SSE2));
+    assert!(flags.contains(&CpuFeature::SSE4_1));
+    assert!(flags.contains(&CpuFeature::SSE4_2));
+    assert!(flags.contains(&CpuFeature::AVX));
+    assert!(flags.contains(&CpuFeature::AVX2));
+    assert!(flags.contains(&CpuFeature::AVX512));
+    assert!(flags.contains(&CpuFeature::FMA));
+    assert!(flags.contains(&CpuFeature::BMI1));
+    assert!(flags.contains(&CpuFeature::BMI2));
+    assert!(flags.contains(&CpuFeature::AESNI));
+    assert!(flags.contains(&CpuFeature::POPCNT));
+}
+
+#[test]
+fn test_detect_cpu_smoke_has_reasonable_values() {
+    let spec = system::detect();
+
+    if cfg!(target_os = "macos") {
+        assert!(matches!(
+            spec.cpu.arch,
+            TargetArch::X86_64 | TargetArch::Aarch64
+        ));
+    } else {
+        assert!(spec.cpu.cores_logical.is_some() || !spec.cpu.features.is_empty());
+    }
+}
+
+#[test]
+fn test_cpu_classify_direct_x86() {
+    let flags = parse_flags("sse2 sse4_2 avx avx2");
+    let class = classify(&TargetArch::X86_64, &flags);
+
+    match class {
+        CpuClass::Avx512 | CpuClass::Avx2 | CpuClass::Avx => {}
+        other => panic!("unexpected x86 class for given flags: {:?}", other),
+    }
+}
+
+#[test]
+fn test_cpu_classify_direct_arm() {
+    let flags = parse_flags("neon");
+    let class = classify(&TargetArch::Aarch64, &flags);
+
+    match class {
+        CpuClass::Sve2 | CpuClass::Sve | CpuClass::Neon | CpuClass::NeonOnly => {}
+        other => panic!("unexpected ARM class for given flags: {:?}", other),
+    }
+}


### PR DESCRIPTION
## Why is this needed?
To detect the system specs and manage the plugins accordingly.
<!-- Briefly explain the motivation behind this change. -->

## What does this PR change?
- Adds the complete `system/` module (OS/CPU/GPU/toolchain/plugins) and targeted errors
- Adds` plugin list` that uses system specs, GitHub Releases API, and Linux fallbacks to show available plugins.
<!-- Summarize the key changes included in this PR. -->

## How has this been tested?
- Tested locally on ubuntu.
- Integration tests for `plugin test` and plugin.rs
<!-- Describe the testing process. If no tests were added, explain why (e.g., already covered, not applicable). -->

## Anything else?
Related : [Wasmedge#4351](https://github.com/WasmEdge/WasmEdge/issues/4351)
<!-- Include screenshots, documentation updates, or anything else relevant. -->
