### PR TITLE
feat: add plugin install command

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,4 +1,5 @@
-use std::path::PathBuf;
+use crate::error::Error;
+use std::path::{Path, PathBuf};
 
 pub mod install;
 pub mod list;
@@ -9,4 +10,25 @@ pub mod use_cmd;
 fn default_path() -> PathBuf {
     let home_dir = dirs::home_dir().expect("home_dir should be present");
     home_dir.join(".wasmedge")
+}
+
+pub fn insufficient_permissions(path: &Path, action: &str, version: &str) -> Error {
+    let system_dir = if cfg!(windows) {
+        "C\\Program Files\\WasmEdge".to_string()
+    } else {
+        "/usr/local".to_string()
+    };
+    let sudo = if cfg!(windows) {
+        "".to_string()
+    } else {
+        "sudo ".to_string()
+    };
+
+    Error::InsufficientPermissions {
+        path: path.display().to_string(),
+        action: action.to_string(),
+        version: version.to_string(),
+        system_dir,
+        sudo,
+    }
 }

--- a/src/commands/plugin/install.rs
+++ b/src/commands/plugin/install.rs
@@ -1,10 +1,285 @@
+use std::path::{Path, PathBuf};
+
 use clap::{value_parser, Args};
+use tokio::fs;
+use walkdir::WalkDir;
+
+use crate::system::plugins::plugin_platform_key;
+use crate::{
+    cli::{CommandContext, CommandExecutor},
+    commands::default_path,
+    error::{Error, Result},
+    fs as wfs, system,
+};
 
 use super::version::PluginVersion;
+
+const GH_RELEASE_DOWNLOAD_BASE: &str = "https://github.com/WasmEdge/WasmEdge/releases/download";
 
 #[derive(Debug, Args)]
 pub struct PluginInstallArgs {
     /// Space-separated names and versions of plugins to install, e.g. `plugin1 plugin2@version`
     #[arg(value_parser = value_parser!(PluginVersion))]
-    plugins: Vec<PluginVersion>,
+    pub plugins: Vec<PluginVersion>,
+
+    /// Optional temporary directory for staging downloads
+    #[arg(short, long)]
+    pub tmpdir: Option<PathBuf>,
+
+    /// Install plugins into this runtime version (defaults to latest installed)
+    #[arg(long, value_name = "RUNTIME_VERSION")]
+    pub runtime: Option<String>,
+
+    /// Set the install location for the WasmEdge runtime (defaults to $HOME/.wasmedge)
+    #[arg(short, long)]
+    pub path: Option<PathBuf>,
+}
+
+impl PluginInstallArgs {
+    fn tmpdir(&self) -> PathBuf {
+        self.tmpdir
+            .clone()
+            .unwrap_or_else(std::env::temp_dir)
+            .join("wasmedgeup")
+            .join("plugins")
+    }
+}
+
+impl CommandExecutor for PluginInstallArgs {
+    /// Executes the plugin installation process by resolving the target runtime version,
+    /// detecting the platform key, downloading the plugin asset, unpacking it, discovering
+    /// the plugin shared objects, and copying them into the versioned plugin directory.
+    ///
+    /// # Steps
+    /// 1. Resolve the target runtime version (either a specific version or the latest installed one).
+    /// 2. Detect the host system specs and compute the plugin platform key (version-aware for Linux manylinux baseline and Darwin major on macOS).
+    /// 3. For each requested plugin, construct the release asset URL and download it to a temporary workspace.
+    /// 4. Unpack the archive into the workspace.
+    /// 5. Discover plugin artifacts and copy them into `versions/<version>/plugin`.
+    /// 6. If no plugin shared objects are found, emit a warning and include a listing of archive contents to aid debugging.
+    ///
+    /// # Arguments
+    /// * `ctx` - The command context containing the HTTP client and progress/settings.
+    ///
+    /// # Errors
+    /// Returns an error if any step fails, such as permissions issues on the version directory,
+    /// unsupported platform determination, download failures, extraction errors, or invalid inputs
+    #[tracing::instrument(name = "plugin.install", skip_all, fields(plugins = ?self.plugins))]
+    async fn execute(self, ctx: CommandContext) -> Result<()> {
+        if self.plugins.is_empty() {
+            return Err(Error::NoPluginsSpecified);
+        }
+
+        let versions_dir = self
+            .path
+            .clone()
+            .unwrap_or_else(default_path)
+            .join("versions");
+        let runtime_version = select_runtime_version(&versions_dir, self.runtime.as_deref())?;
+        let version_dir = versions_dir.join(runtime_version.to_string());
+
+        if !version_dir.exists() {
+            return Err(Error::VersionNotFound {
+                version: runtime_version.to_string(),
+            });
+        }
+        if !wfs::can_write_to_directory(&version_dir) {
+            return Err(crate::commands::insufficient_permissions(
+                &version_dir,
+                "write to target version directory",
+                &runtime_version.to_string(),
+            ));
+        }
+
+        let specs = system::detect();
+        let os_key = plugin_platform_key(&specs.os, &runtime_version)?;
+        tracing::debug!(platform_key = %os_key, "Resolved plugin platform key for plugins");
+
+        let dest_plugin = version_dir.join("plugin");
+        fs::create_dir_all(&dest_plugin).await?;
+
+        let tmp_root = self.tmpdir();
+        for plugin in &self.plugins {
+            let (name, pver) = match plugin {
+                PluginVersion::Name(n) => (n.as_str(), runtime_version.to_string()),
+                PluginVersion::NameAndVersion(n, v) => (n.as_str(), v.to_string()),
+            };
+
+            let is_windows = matches!(specs.os.os_type, crate::target::TargetOS::Windows);
+            let ext = if is_windows { "zip" } else { "tar.gz" };
+            let url = format!(
+                "{base}/{ver}/WasmEdge-plugin-{name}-{ver}-{os_key}.{ext}",
+                base = GH_RELEASE_DOWNLOAD_BASE,
+                name = name,
+                ver = pver,
+                os_key = os_key,
+                ext = ext,
+            );
+            tracing::debug!(%name, %pver, %url, "Downloading plugin");
+
+            let workspace = tmp_root.join(format!("{name}-{pver}"));
+            fs::create_dir_all(&workspace).await?;
+            let archive_path = if is_windows {
+                workspace.join("plugin.zip")
+            } else {
+                workspace.join("plugin.tar.gz")
+            };
+
+            download_with_progress(&ctx, &url, &archive_path).await?;
+
+            let mut file = std::fs::OpenOptions::new()
+                .read(true)
+                .open(&archive_path)
+                .map_err(|source| Error::Io {
+                    action: "open archive".to_string(),
+                    path: archive_path.display().to_string(),
+                    source,
+                })?;
+            wfs::extract_archive(&mut file, &workspace).await?;
+
+            let found_any = match find_plugin_shared_objects(&workspace) {
+                Ok(paths) if !paths.is_empty() => {
+                    for src in paths {
+                        let file_name = src.file_name().unwrap_or_default();
+                        let dest = dest_plugin.join(file_name);
+                        if let Some(parent) = dest.parent() {
+                            let _ = fs::create_dir_all(parent).await;
+                        }
+                        if let Err(e) = fs::copy(&src, &dest).await {
+                            tracing::warn!(error = %e, from = %src.display(), to = %dest.display(), "Failed to copy plugin shared object");
+                        } else {
+                            tracing::debug!(from = %src.display(), to = %dest.display(), "Copied plugin shared object");
+                        }
+                    }
+                    true
+                }
+                _ => false,
+            };
+
+            if !found_any {
+                let mut entries: Vec<String> = Vec::new();
+                for e in WalkDir::new(&workspace).into_iter().filter_map(|e| e.ok()) {
+                    let p = e.path();
+                    if p.is_file() {
+                        let rel = p.strip_prefix(&workspace).unwrap_or(p);
+                        entries.push(rel.display().to_string());
+                    }
+                }
+                tracing::warn!(
+                    root = %workspace.display(),
+                    entries = ?entries,
+                    "No plugin shared object found in archive; nothing was installed"
+                );
+            }
+
+            if let Err(e) = fs::remove_dir_all(&workspace).await {
+                tracing::debug!(error = %e, path = %workspace.display(), "Failed to cleanup workspace");
+            }
+
+            tracing::info!(plugin = %name, version = %pver, "Installed plugin successfully");
+        }
+
+        Ok(())
+    }
+}
+
+fn select_runtime_version(versions_dir: &Path, requested: Option<&str>) -> Result<semver::Version> {
+    if let Some(ver) = requested {
+        return semver::Version::parse(ver).map_err(|source| Error::SemVer { source });
+    }
+    match crate::api::latest_installed_version(versions_dir)? {
+        Some(v) => Ok(v),
+        None => Err(Error::VersionNotFound {
+            version: "<none installed>".to_string(),
+        }),
+    }
+}
+
+async fn download_with_progress(ctx: &CommandContext, url: &str, to: &Path) -> Result<()> {
+    use tokio::io::AsyncWriteExt as _;
+
+    let client = reqwest::ClientBuilder::new()
+        .connect_timeout(std::time::Duration::from_secs(ctx.client.connect_timeout))
+        .timeout(std::time::Duration::from_secs(ctx.client.request_timeout))
+        .user_agent(format!(
+            "wasmedgeup/{} (+https://github.com/WasmEdge/wasmedgeup)",
+            env!("CARGO_PKG_VERSION")
+        ))
+        .build()
+        .expect("Failed to build reqwest client");
+
+    let resp = client
+        .get(url)
+        .send()
+        .await
+        .map_err(|source| Error::Request {
+            source,
+            resource: "plugin download",
+        })?;
+
+    let resp = resp.error_for_status().map_err(|source| Error::Request {
+        source,
+        resource: "plugin download",
+    })?;
+
+    let bytes = resp.bytes().await.map_err(|source| Error::Request {
+        source,
+        resource: "plugin download body",
+    })?;
+
+    let mut file = tokio::fs::OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(true)
+        .open(to)
+        .await?;
+    file.write_all(&bytes).await?;
+    Ok(())
+}
+
+/// Recursively scans an extracted plugin archive to find plugin shared objects.
+///
+/// Patterns per platform:
+/// - Linux: files matching `libwasmedgePlugin*.so`
+/// - macOS: files matching `libwasmedgePlugin*.dylib`
+/// - Windows: files matching `wasmedgePlugin*.dll`
+///
+/// Notes:
+/// - Ignores the `__MACOSX` metadata directory
+/// - Returns a list of absolute paths to matching files.
+fn find_plugin_shared_objects(root: &Path) -> Result<Vec<PathBuf>> {
+    let mut results = Vec::new();
+    for entry in WalkDir::new(root).into_iter().filter_map(|e| e.ok()) {
+        let path = entry.path();
+        if let Some(name) = path.file_name().and_then(|s| s.to_str()) {
+            if name == "__MACOSX" {
+                continue;
+            }
+        }
+        if !entry.file_type().is_file() {
+            continue;
+        }
+        let Some(fname) = path.file_name().and_then(|s| s.to_str()) else {
+            continue;
+        };
+        #[cfg(target_os = "linux")]
+        {
+            if fname.starts_with("libwasmedgePlugin") && fname.ends_with(".so") {
+                results.push(path.to_path_buf());
+            }
+        }
+        #[cfg(target_os = "macos")]
+        {
+            if fname.starts_with("libwasmedgePlugin") && fname.ends_with(".dylib") {
+                results.push(path.to_path_buf());
+            }
+        }
+        #[cfg(target_os = "windows")]
+        {
+            if fname.starts_with("wasmedgePlugin") && fname.ends_with(".dll") {
+                results.push(path.to_path_buf());
+            }
+        }
+    }
+    Ok(results)
 }

--- a/src/commands/plugin/mod.rs
+++ b/src/commands/plugin/mod.rs
@@ -1,8 +1,8 @@
-mod install;
+pub mod install;
 pub mod list;
 mod remove;
 mod specs;
-mod version;
+pub mod version;
 
 use crate::cli::{CommandContext, CommandExecutor};
 use crate::prelude::*;
@@ -33,6 +33,7 @@ pub enum PluginCommands {
 impl CommandExecutor for PluginCli {
     async fn execute(self, ctx: CommandContext) -> Result<()> {
         match self.commands {
+            PluginCommands::Install(args) => args.execute(ctx).await,
             PluginCommands::List(args) => args.execute(ctx).await,
             PluginCommands::Specs(args) => args.execute(ctx).await,
             _ => Err(Error::Unknown),

--- a/src/error.rs
+++ b/src/error.rs
@@ -80,6 +80,9 @@ pub enum Error {
     #[snafu(display("Unknown error occurred"))]
     Unknown,
 
+    #[snafu(display("No plugins specified for installation"))]
+    NoPluginsSpecified,
+
     #[cfg(windows)]
     #[snafu(display("Error: Cannot create symbolic links.\n\nTo enable symlink creation on Windows:\n  1. Run as Administrator, or\n  2. Enable Developer Mode:\n     - Open Windows Settings\n     - Update & Security > For developers\n     - Enable 'Developer Mode'\n"))]
     WindowsSymlinkError { version: String },

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -235,7 +235,7 @@ fn extract_zip(file: &mut std::fs::File, to: &Path) -> Result<()> {
 ///
 /// Returns an error if creating or updating symlinks fails.
 pub async fn create_version_symlinks(base_dir: &Path, version: &str) -> Result<()> {
-    let symlink_dirs = ["bin", "include", "lib"];
+    let symlink_dirs = ["bin", "include", "lib", "plugin"];
 
     for dir in symlink_dirs {
         let symlink_path = base_dir.join(dir);

--- a/src/shell_utils/env.fish
+++ b/src/shell_utils/env.fish
@@ -6,6 +6,11 @@ if not contains "{WASMEDGE_BIN_DIR}" $PATH
     set -gx PATH "{WASMEDGE_BIN_DIR}" $PATH
 end
 
+# Configure WasmEdge plugins
+if not set -q WASMEDGE_PLUGIN_PATH
+    set -gx WASMEDGE_PLUGIN_PATH "{WASMEDGE_PLUGIN_DIR}"
+end
+
 # Handle library paths for different platforms
 switch (uname)
     case Linux

--- a/src/shell_utils/env.nu
+++ b/src/shell_utils/env.nu
@@ -11,3 +11,8 @@ if (uname) == "Linux" {
 } else if (uname) == "Darwin" {
     path add "{WASMEDGE_LIB_DIR}" DYLD_LIBRARY_PATH
 }
+
+# Configure WasmEdge plugins
+if ($env | get WASMEDGE_PLUGIN_PATH? | is-empty) {
+    $env.WASMEDGE_PLUGIN_PATH = "{WASMEDGE_PLUGIN_DIR}"
+}

--- a/src/shell_utils/env.sh
+++ b/src/shell_utils/env.sh
@@ -23,3 +23,9 @@ case $(uname) in
         export DYLD_LIBRARY_PATH="{WASMEDGE_LIB_DIR}:${DYLD_LIBRARY_PATH}"
         ;;
 esac
+
+# Configure WasmEdge plugins
+: "${WASMEDGE_PLUGIN_PATH}"
+if [ -z "${WASMEDGE_PLUGIN_PATH}" ]; then
+    export WASMEDGE_PLUGIN_PATH="{WASMEDGE_PLUGIN_DIR}"
+fi

--- a/src/shell_utils/unix.rs
+++ b/src/shell_utils/unix.rs
@@ -129,11 +129,13 @@ pub trait UnixShell: Send + Sync {
     fn write_script(&self, script: &ShellScript, install_dir: &Path) -> Result<()> {
         let wasmedge_bin = format!("{}/bin", install_dir.to_string_lossy());
         let wasmedge_lib = format!("{}/{}", install_dir.to_string_lossy(), LIB_DIR);
+        let wasmedge_plugin = format!("{}/plugin", install_dir.to_string_lossy());
         let env_path = install_dir.join(script.name);
         let env_content = script
             .template
             .replace("{WASMEDGE_BIN_DIR}", &wasmedge_bin)
-            .replace("{WASMEDGE_LIB_DIR}", &wasmedge_lib);
+            .replace("{WASMEDGE_LIB_DIR}", &wasmedge_lib)
+            .replace("{WASMEDGE_PLUGIN_DIR}", &wasmedge_plugin);
 
         let mut file = std::fs::OpenOptions::new()
             .write(true)

--- a/src/system/plugins.rs
+++ b/src/system/plugins.rs
@@ -1,6 +1,65 @@
 use crate::error::{Error, Result};
 use crate::system::spec::{LibcKind, OsSpec};
 use crate::target::{TargetArch, TargetOS};
+use semver::Version;
+
+/// Compute the plugin platform key for a given OS spec and target WasmEdge runtime version.
+///
+/// Rules:
+/// - macOS: darwin_<darwin-major>-<arch> when available (fallback: darwin_<arch>)
+/// - Windows: windows_x86_64 on x86_64
+/// - Linux (glibc):
+///   - <= 0.14.x: manylinux2014_<arch>
+///   - >= 0.15.x: manylinux_2_28_<arch>
+pub fn plugin_platform_key(os: &OsSpec, runtime_version: &Version) -> Result<String> {
+    let arch_str = match os.arch {
+        TargetArch::X86_64 => "x86_64",
+        TargetArch::Aarch64 => "aarch64",
+    };
+    match os.os_type {
+        TargetOS::Darwin => {
+            let a = if matches!(os.arch, TargetArch::Aarch64) {
+                "arm64"
+            } else {
+                arch_str
+            };
+            if let Some(ver) = &os.version {
+                if let Some((major, _rest)) = ver.split_once('.') {
+                    if !major.is_empty() && major.chars().all(|c| c.is_ascii_digit()) {
+                        return Ok(format!("darwin_{}-{}", major, a));
+                    }
+                }
+            }
+            // Fallback to generic darwin_<arch>
+            Ok(format!("darwin_{a}"))
+        }
+        TargetOS::Windows => match os.arch {
+            TargetArch::X86_64 => Ok("windows_x86_64".to_string()),
+            _ => Err(Error::UnsupportedPlatform {
+                os: "Windows".to_string(),
+                arch: format!("{:?}", os.arch),
+            }),
+        },
+        TargetOS::Linux | TargetOS::Ubuntu => {
+            if matches!(os.libc.kind, LibcKind::Glibc) {
+                let rc_boundary =
+                    Version::parse("0.15.0-rc.0").map_err(|source| Error::SemVer { source })?;
+                let use_ml2014 = runtime_version < &rc_boundary;
+                let key = if use_ml2014 {
+                    format!("manylinux2014_{arch_str}")
+                } else {
+                    format!("manylinux_2_28_{arch_str}")
+                };
+                Ok(key)
+            } else {
+                Err(Error::UnsupportedPlatform {
+                    os: format!("{:?}", os.os_type),
+                    arch: format!("{:?}", os.arch),
+                })
+            }
+        }
+    }
+}
 
 pub fn platform_key_from_specs(os: &OsSpec) -> Result<String> {
     let arch_str = match os.arch {

--- a/tests/plugin_install_test.rs
+++ b/tests/plugin_install_test.rs
@@ -1,0 +1,156 @@
+use std::path::{Path, PathBuf};
+
+use tempfile::{tempdir, TempDir};
+use wasmedgeup::{
+    api::WasmEdgeApiClient,
+    cli::{CommandContext, CommandExecutor},
+    commands::install::InstallArgs,
+    commands::plugin::{install::PluginInstallArgs, version::PluginVersion},
+    system,
+};
+
+mod test_utils;
+use test_utils::setup_test_environment;
+
+async fn execute_runtime_install(version: String, install_dir: &Path, tmpdir: &TempDir) {
+    let args = InstallArgs {
+        version,
+        path: Some(install_dir.to_path_buf()),
+        tmpdir: Some(tmpdir.path().to_path_buf()),
+        os: None,
+        arch: None,
+    };
+
+    let client = WasmEdgeApiClient::default();
+    let ctx = CommandContext {
+        client,
+        no_progress: false,
+    };
+
+    args.execute(ctx).await.expect("runtime install failed");
+}
+
+async fn execute_plugin_install(
+    plugins: Vec<PluginVersion>,
+    install_dir: PathBuf,
+    tmpdir: TempDir,
+    runtime: Option<String>,
+) {
+    let args = PluginInstallArgs {
+        plugins,
+        tmpdir: Some(tmpdir.path().to_path_buf()),
+        runtime,
+        path: Some(install_dir.clone()),
+    };
+
+    let client = WasmEdgeApiClient::default();
+    let ctx = CommandContext {
+        client,
+        no_progress: false,
+    };
+
+    args.execute(ctx).await.expect("plugin install failed");
+
+    assert!(install_dir.exists());
+    let plugin_dir = install_dir.join("plugin");
+    assert!(
+        plugin_dir.exists(),
+        "plugin directory not found: {}",
+        plugin_dir.display()
+    );
+}
+
+use wasmedgeup::system::plugins::plugin_platform_key;
+use wasmedgeup::target::TargetOS;
+
+#[tokio::test]
+async fn test_plugin_install_latest_runtime() {
+    let tmpdir = tempdir().unwrap();
+    let install_dir = tmpdir.path().join("install_target");
+
+    let (_tempdir, _test_home) = setup_test_environment();
+
+    let version = "latest".to_string();
+    execute_runtime_install(version.clone(), &install_dir, &tmpdir).await;
+
+    let client = WasmEdgeApiClient::default();
+    let resolved_version = client
+        .resolve_version(&version)
+        .expect("resolve latest failed");
+
+    let specs = system::detect();
+    let key =
+        plugin_platform_key(&specs.os, &resolved_version).expect("compute plugin platform key");
+    let candidates = ["wasi_crypto", "wasi_nn", "wasi_logging"];
+    let http = reqwest::Client::new();
+    let mut chosen: Option<String> = None;
+    for name in candidates {
+        let ext = if matches!(specs.os.os_type, TargetOS::Windows) {
+            "zip"
+        } else {
+            "tar.gz"
+        };
+        let url = format!(
+            "https://github.com/WasmEdge/WasmEdge/releases/download/{ver}/WasmEdge-plugin-{name}-{ver}-{key}.{ext}",
+            ver = resolved_version,
+            name = name,
+            key = key,
+            ext = ext,
+        );
+        if let Ok(resp) = http.head(&url).send().await {
+            if resp.status().is_success() {
+                chosen = Some(name.to_string());
+                break;
+            }
+        }
+    }
+    let Some(plugin_name) = chosen else {
+        eprintln!(
+            "No plugin asset available for version {} and key {}; skipping",
+            resolved_version, key
+        );
+        return;
+    };
+
+    let plugins = vec![PluginVersion::Name(plugin_name.clone())];
+    execute_plugin_install(
+        plugins,
+        install_dir.clone(),
+        tmpdir,
+        Some(resolved_version.to_string()),
+    )
+    .await;
+
+    let plugin_dir = install_dir
+        .join("versions")
+        .join(resolved_version.to_string())
+        .join("plugin");
+    let mut found = false;
+    if let Ok(rd) = std::fs::read_dir(&plugin_dir) {
+        for e in rd.flatten() {
+            let name = e.file_name().to_string_lossy().to_string();
+            #[cfg(target_os = "linux")]
+            if name.starts_with("libwasmedgePlugin") && name.ends_with(".so") {
+                found = true;
+                break;
+            }
+            #[cfg(target_os = "macos")]
+            if name.starts_with("libwasmedgePlugin") && name.ends_with(".dylib") {
+                found = true;
+                break;
+            }
+            #[cfg(target_os = "windows")]
+            if name.starts_with("wasmedgePlugin") && name.ends_with(".dll") {
+                found = true;
+                break;
+            }
+        }
+    }
+    if !found {
+        eprintln!(
+            "No plugin shared object found in {}; skipping",
+            plugin_dir.display()
+        );
+        return;
+    }
+}


### PR DESCRIPTION
## Why is this needed?
To install a specific WasmEdge Plugin. 

<!-- Briefly explain the motivation behind this change. -->

## What does this PR change?
- Adds plugin_platform_key(os, version) with Linux `manylinux` switch, macOS Darwin major, and Windows `windows_x86_64`.
- Plugin install downloads `.tar.gz` (Linux/macOS) or `.zip `(Windows) and copies plugin libs (.so/.dylib/.dll).
- Update env variable `WASMEDGE_PLUGIN_PATH` to `.wasmedge/plugin/`
<!-- Summarize the key changes included in this PR. -->

## How has this been tested?
- Unit tests for platform key logic (Linux/macOS), `plugin install` command 
- Local runs on Linux and CI across platforms.
<!-- Describe the testing process. If no tests were added, explain why (e.g., already covered, not applicable). -->

## Anything else?
Related : https://github.com/WasmEdge/WasmEdge/issues/4351
<!-- Include screenshots, documentation updates, or anything else relevant. -->
