### PR TITLE
feat: implement plugin remove command

### DIFF
--- a/src/commands/plugin/install.rs
+++ b/src/commands/plugin/install.rs
@@ -183,7 +183,10 @@ impl CommandExecutor for PluginInstallArgs {
     }
 }
 
-fn select_runtime_version(versions_dir: &Path, requested: Option<&str>) -> Result<semver::Version> {
+pub(super) fn select_runtime_version(
+    versions_dir: &Path,
+    requested: Option<&str>,
+) -> Result<semver::Version> {
     if let Some(ver) = requested {
         return semver::Version::parse(ver).map_err(|source| Error::SemVer { source });
     }

--- a/src/commands/plugin/mod.rs
+++ b/src/commands/plugin/mod.rs
@@ -1,6 +1,6 @@
 pub mod install;
 pub mod list;
-mod remove;
+pub mod remove;
 mod specs;
 pub mod version;
 
@@ -35,8 +35,8 @@ impl CommandExecutor for PluginCli {
         match self.commands {
             PluginCommands::Install(args) => args.execute(ctx).await,
             PluginCommands::List(args) => args.execute(ctx).await,
+            PluginCommands::Remove(args) => args.execute(ctx).await,
             PluginCommands::Specs(args) => args.execute(ctx).await,
-            _ => Err(Error::Unknown),
         }
     }
 }

--- a/src/commands/plugin/remove.rs
+++ b/src/commands/plugin/remove.rs
@@ -1,10 +1,201 @@
+use std::collections::{BTreeMap, HashSet};
+use std::path::{Path, PathBuf};
+
 use clap::Args;
 
+use super::install::select_runtime_version;
 use super::version::PluginVersion;
+use crate::commands::default_path;
+use crate::{
+    cli::{CommandContext, CommandExecutor},
+    error::{Error, Result},
+};
 
 #[derive(Debug, Args)]
 pub struct PluginRemoveArgs {
-    /// Space-separated names and versions of plugins to remove, e.g. `plugin1 plugin2@version`
+    /// Names and versions of plugins to remove, e.g. `plugin1 plugin2@version`
     #[arg(value_parser = clap::value_parser!(PluginVersion))]
-    plugins: Vec<PluginVersion>,
+    pub plugins: Vec<PluginVersion>,
+
+    /// Remove plugins from this runtime version (defaults to latest installed)
+    #[arg(long, value_name = "RUNTIME_VERSION")]
+    pub runtime: Option<String>,
+
+    /// Set the install location for the WasmEdge runtime (defaults to $HOME/.wasmedge)
+    #[arg(short, long)]
+    pub path: Option<PathBuf>,
+}
+
+fn normalize_name(s: &str) -> String {
+    s.chars()
+        .filter(|c| c.is_ascii_alphanumeric())
+        .flat_map(|c| c.to_lowercase())
+        .collect()
+}
+
+impl CommandExecutor for PluginRemoveArgs {
+    #[tracing::instrument(name = "plugin.remove", skip_all, fields(plugins = ?self.plugins))]
+    async fn execute(self, _ctx: CommandContext) -> Result<()> {
+        if self.plugins.is_empty() {
+            return Err(Error::NoPluginsSpecified);
+        }
+
+        let versions_dir = self
+            .path
+            .clone()
+            .unwrap_or_else(default_path)
+            .join("versions");
+
+        let runtime_version = select_runtime_version(&versions_dir, self.runtime.as_deref())?;
+        let version_dir = versions_dir.join(runtime_version.to_string());
+
+        if !version_dir.exists() {
+            return Err(Error::VersionNotFound {
+                version: runtime_version.to_string(),
+            });
+        }
+
+        let plugin_dir = version_dir.join("plugin");
+        let stable_plugin_dir = versions_dir
+            .parent()
+            .unwrap_or(&versions_dir)
+            .join("plugin");
+
+        let mut by_name: BTreeMap<String, Vec<PathBuf>> = BTreeMap::new();
+
+        let mut searched_dirs: Vec<PathBuf> = Vec::new();
+        if plugin_dir.exists() {
+            searched_dirs.push(plugin_dir.clone());
+        }
+        if stable_plugin_dir.exists() {
+            searched_dirs.push(stable_plugin_dir.clone());
+        }
+
+        for dir in &searched_dirs {
+            let mut rd = tokio::fs::read_dir(dir).await?;
+            while let Some(entry) = rd.next_entry().await? {
+                let path = entry.path();
+                if !entry
+                    .file_type()
+                    .await
+                    .map(|t| t.is_file())
+                    .unwrap_or(false)
+                {
+                    continue;
+                }
+                if let Some(raw_name) = extract_plugin_name(&path) {
+                    let norm = normalize_name(&raw_name);
+                    by_name.entry(raw_name).or_default().push(path.clone());
+                    by_name.entry(norm).or_default().push(path.clone());
+                }
+            }
+        }
+
+        if by_name.is_empty() {
+            tracing::info!(
+                dirs = ?searched_dirs,
+                "No plugin files found to remove in any plugin directory"
+            );
+            return Ok(());
+        }
+
+        let mut requested: Vec<String> = Vec::new();
+        for p in self.plugins {
+            match p {
+                PluginVersion::Name(n) => requested.push(n),
+                PluginVersion::NameAndVersion(n, v) => {
+                    tracing::warn!(
+                        plugin = %n,
+                        version = %v,
+                        "Plugin remove does not track per-plugin version on disk; removing by name"
+                    );
+                    requested.push(n)
+                }
+            }
+        }
+
+        let mut removed_any = false;
+        let mut removed_targets: HashSet<PathBuf> = HashSet::new();
+        let mut missing: Vec<String> = Vec::new();
+        for want in requested {
+            let key_norm = normalize_name(&want);
+            if let Some(files) = by_name.get(&want).or_else(|| by_name.get(&key_norm)) {
+                for f in files {
+                    let real = tokio::fs::canonicalize(f)
+                        .await
+                        .unwrap_or_else(|_| f.clone());
+                    if removed_targets.contains(&real) {
+                        continue;
+                    }
+                    match tokio::fs::remove_file(f).await {
+                        Ok(_) => {
+                            tracing::info!(plugin = %want, path = %f.display(), "Removed plugin file");
+                            removed_targets.insert(real);
+                            removed_any = true;
+                        }
+                        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                            tracing::debug!(path = %f.display(), "Plugin file already removed; skipping");
+                            removed_targets.insert(real);
+                            removed_any = true;
+                        }
+                        Err(e) => {
+                            tracing::warn!(error = %e, path = %f.display(), "Failed to remove plugin file");
+                        }
+                    }
+                }
+            } else {
+                missing.push(want);
+            }
+        }
+
+        if !missing.is_empty() {
+            tracing::warn!(missing = ?missing, "Requested plugins not found");
+        }
+
+        if removed_any {
+            for dir in [&plugin_dir, &stable_plugin_dir] {
+                if let Ok(mut rd) = tokio::fs::read_dir(dir).await {
+                    let mut any_file = false;
+                    while let Ok(Some(e)) = rd.next_entry().await {
+                        if e.file_type().await.map(|t| t.is_file()).unwrap_or(false) {
+                            any_file = true;
+                            break;
+                        }
+                    }
+                    if !any_file {
+                        if let Err(e) = tokio::fs::remove_dir(dir).await {
+                            tracing::debug!(error = %e, dir = %dir.display(), "Failed to remove empty plugin directory");
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+pub fn extract_plugin_name(path: &Path) -> Option<String> {
+    let fname = path.file_name()?.to_str()?;
+    #[cfg(target_os = "linux")]
+    {
+        fname
+            .strip_prefix("libwasmedgePlugin")
+            .and_then(|rest| rest.strip_suffix(".so"))
+            .map(|core| core.to_string())
+    }
+    #[cfg(target_os = "macos")]
+    {
+        fname
+            .strip_prefix("libwasmedgePlugin")
+            .and_then(|rest| rest.strip_suffix(".dylib"))
+            .map(|core| core.to_string())
+    }
+    #[cfg(target_os = "windows")]
+    {
+        fname
+            .strip_prefix("wasmedgePlugin")
+            .and_then(|rest| rest.strip_suffix(".dll"))
+            .map(|core| core.to_string())
+    }
 }

--- a/tests/plugin_remove_tests.rs
+++ b/tests/plugin_remove_tests.rs
@@ -1,0 +1,191 @@
+use std::path::{Path, PathBuf};
+
+use wasmedgeup::{
+    api::WasmEdgeApiClient,
+    cli::{CommandContext, CommandExecutor},
+    commands::plugin::remove::{extract_plugin_name, PluginRemoveArgs},
+};
+
+mod test_utils;
+
+fn p(s: &str) -> &Path {
+    Path::new(s)
+}
+
+#[cfg_attr(not(target_os = "linux"), ignore = "Linux-specific test")]
+#[test]
+fn test_extract_plugin_name_linux() {
+    assert_eq!(
+        extract_plugin_name(p("/tmp/libwasmedgePluginwasi_nn.so")).as_deref(),
+        Some("wasi_nn")
+    );
+    assert_eq!(
+        extract_plugin_name(p("libwasmedgePluginwasi_logging.so")).as_deref(),
+        Some("wasi_logging")
+    );
+    // wrong prefix
+    assert_eq!(extract_plugin_name(p("wasmedgePluginfoo.so")), None);
+    // wrong suffix
+    assert_eq!(extract_plugin_name(p("libwasmedgePluginfoo.dll")), None);
+}
+
+#[cfg_attr(not(target_os = "macos"), ignore = "macOS-specific test")]
+#[test]
+fn test_extract_plugin_name_macos() {
+    assert_eq!(
+        extract_plugin_name(p("/tmp/libwasmedgePluginwasi_nn.dylib")).as_deref(),
+        Some("wasi_nn")
+    );
+    assert_eq!(
+        extract_plugin_name(p("libwasmedgePluginwasi_logging.dylib")).as_deref(),
+        Some("wasi_logging")
+    );
+    // wrong prefix
+    assert_eq!(extract_plugin_name(p("wasmedgePluginfoo.dylib")), None);
+    // wrong suffix
+    assert_eq!(extract_plugin_name(p("libwasmedgePluginfoo.so")), None);
+}
+
+#[cfg_attr(not(target_os = "windows"), ignore = "Windows-specific test")]
+#[test]
+fn test_extract_plugin_name_windows() {
+    assert_eq!(
+        extract_plugin_name(p("C:/Temp/wasmedgePluginwasi_nn.dll")).as_deref(),
+        Some("wasi_nn")
+    );
+    assert_eq!(
+        extract_plugin_name(p("wasmedgePluginwasi_logging.dll")).as_deref(),
+        Some("wasi_logging")
+    );
+    // wrong prefix
+    assert_eq!(extract_plugin_name(p("libwasmedgePluginfoo.dll")), None);
+    // wrong suffix
+    assert_eq!(extract_plugin_name(p("wasmedgePluginfoo.dylib")), None);
+}
+
+fn plugin_filename_for(name: &str) -> String {
+    #[cfg(target_os = "linux")]
+    {
+        format!("libwasmedgePlugin{name}.so")
+    }
+    #[cfg(target_os = "macos")]
+    {
+        format!("libwasmedgePlugin{name}.dylib")
+    }
+    #[cfg(target_os = "windows")]
+    {
+        format!("wasmedgePlugin{name}.dll")
+    }
+}
+
+async fn setup_mock_runtime_with_plugins(root: &Path, version: &str, plugins: &[&str]) -> PathBuf {
+    let plugin_dir = root.join("versions").join(version).join("plugin");
+    tokio::fs::create_dir_all(&plugin_dir).await.unwrap();
+
+    for n in plugins {
+        let fname = plugin_filename_for(n);
+        tokio::fs::write(plugin_dir.join(fname), format!("mock plugin: {n}"))
+            .await
+            .unwrap();
+    }
+    plugin_dir
+}
+
+#[tokio::test]
+async fn test_plugin_remove_single() {
+    let (_tmp, home) = test_utils::setup_test_environment();
+    let version = "0.14.1";
+    let plugin_dir =
+        setup_mock_runtime_with_plugins(&home, version, &["wasi_nn", "wasi_logging"]).await;
+
+    let args = PluginRemoveArgs {
+        plugins: vec!["wasi_nn".parse().unwrap()],
+        runtime: Some(version.to_string()),
+        path: Some(home.clone()),
+    };
+    let ctx = CommandContext {
+        client: WasmEdgeApiClient::default(),
+        no_progress: true,
+    };
+    args.execute(ctx).await.unwrap();
+
+    assert!(!plugin_dir.join(plugin_filename_for("wasi_nn")).exists());
+    assert!(plugin_dir
+        .join(plugin_filename_for("wasi_logging"))
+        .exists());
+}
+
+#[tokio::test]
+async fn test_plugin_remove_multiple_and_cleanup_empty_dir() {
+    let (_tmp, home) = test_utils::setup_test_environment();
+    let version = "0.15.0";
+    let plugin_dir =
+        setup_mock_runtime_with_plugins(&home, version, &["wasi_nn", "wasi_logging"]).await;
+
+    let args = PluginRemoveArgs {
+        plugins: vec!["wasi_nn".parse().unwrap(), "wasi_logging".parse().unwrap()],
+        runtime: Some(version.to_string()),
+        path: Some(home.clone()),
+    };
+    let ctx = CommandContext {
+        client: WasmEdgeApiClient::default(),
+        no_progress: true,
+    };
+    args.execute(ctx).await.unwrap();
+
+    if plugin_dir.exists() {
+        let mut entries = tokio::fs::read_dir(&plugin_dir).await.unwrap();
+        let mut any = false;
+        while let Some(e) = entries.next_entry().await.unwrap() {
+            if e.file_type().await.unwrap().is_file() {
+                any = true;
+                break;
+            }
+        }
+        assert!(!any, "plugin dir should be empty");
+    }
+}
+
+#[tokio::test]
+async fn test_plugin_remove_nonexistent_is_noop() {
+    let (_tmp, home) = test_utils::setup_test_environment();
+    let version = "0.14.1";
+    let plugin_dir = setup_mock_runtime_with_plugins(&home, version, &["wasi_nn"]).await;
+
+    let args = PluginRemoveArgs {
+        plugins: vec!["not_exists".parse().unwrap()],
+        runtime: Some(version.to_string()),
+        path: Some(home.clone()),
+    };
+    let ctx = CommandContext {
+        client: WasmEdgeApiClient::default(),
+        no_progress: true,
+    };
+    args.execute(ctx).await.unwrap();
+
+    assert!(plugin_dir.join(plugin_filename_for("wasi_nn")).exists());
+}
+
+#[tokio::test]
+async fn test_plugin_remove_when_no_plugin_dir() {
+    let (_tmp, home) = test_utils::setup_test_environment();
+    let version = "0.14.1";
+    let version_dir = home.join("versions").join(version);
+    tokio::fs::create_dir_all(&version_dir).await.unwrap();
+
+    let args = PluginRemoveArgs {
+        plugins: vec!["wasi_nn".parse().unwrap()],
+        runtime: Some(version.to_string()),
+        path: Some(home.clone()),
+    };
+    let ctx = CommandContext {
+        client: WasmEdgeApiClient::default(),
+        no_progress: true,
+    };
+    args.execute(ctx).await.unwrap();
+
+    assert!(
+        !version_dir.join("plugin").exists(),
+        "no plugin dir should be created by remove"
+    );
+}


### PR DESCRIPTION
## Why is this needed?
- To uninstall specific WasmEdge plugins.
<!-- Briefly explain the motivation behind this change. -->

## What does this PR change?
- Adds plugin remove command:
 - Removes plugin libs from `~/.wasmedge/versions/<ver>/plugin` and `~/.wasmedge/plugin`.
 - Name matching is case-/style-insensitive.
 - Supports plugin@version as runtime selector
<!-- Summarize the key changes included in this PR. -->

## How has this been tested?
- Unit/integration tests for removal, normalization, runtime selection, and conflicts.
- Local runs on Linux and CI across platforms.
<!-- Describe the testing process. If no tests were added, explain why (e.g., already covered, not applicable). -->

## Anything else?
Related : https://github.com/WasmEdge/WasmEdge/issues/4351

<!-- Include screenshots, documentation updates, or anything else relevant. -->
