### PR TITLE
refactor: phase 1 cleanups — cargo hygiene and dead-code removal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,15 +20,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "aho-corasick"
-version = "1.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -700,12 +691,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
-name = "futures-timer"
-version = "3.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
-
-[[package]]
 name = "futures-util"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -788,12 +773,6 @@ dependencies = [
  "openssl-sys",
  "url",
 ]
-
-[[package]]
-name = "glob"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "h2"
@@ -1623,15 +1602,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-crate"
-version = "3.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
-dependencies = [
- "toml_edit",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1785,41 +1755,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex"
-version = "1.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.8.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
-
-[[package]]
-name = "relative-path"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
-
-[[package]]
 name = "reqwest"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1872,48 +1807,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "rstest"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5a3193c063baaa2a95a33f03035c8a72b83d97a54916055ba22d35ed3839d49"
-dependencies = [
- "futures-timer",
- "futures-util",
- "rstest_macros",
-]
-
-[[package]]
-name = "rstest_macros"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c845311f0ff7951c5506121a9ad75aec44d083c31583b2ea5a30bcb0b0abba0"
-dependencies = [
- "cfg-if",
- "glob",
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "regex",
- "relative-path",
- "rustc_version",
- "syn",
- "unicode-ident",
-]
-
-[[package]]
 name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
-
-[[package]]
-name = "rustc_version"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
-dependencies = [
- "semver",
-]
 
 [[package]]
 name = "rustix"
@@ -2501,36 +2398,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml_datetime"
-version = "1.1.1+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
-dependencies = [
- "serde_core",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.25.11+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
-dependencies = [
- "indexmap",
- "toml_datetime",
- "toml_parser",
- "winnow",
-]
-
-[[package]]
-name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
-dependencies = [
- "winnow",
-]
-
-[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2857,7 +2724,6 @@ dependencies = [
  "opencl3",
  "raw-cpuid",
  "reqwest",
- "rstest",
  "semver",
  "serde",
  "serde_json",
@@ -3301,15 +3167,6 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
-
-[[package]]
-name = "winnow"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "winreg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "wasmedgeup"
 version = "0.1.3"
 edition = "2021"
+rust-version = "1.85"
 authors = ["hydai <hydai@secondstate.io>"]
 description = "An installer for the Wasmedge runtime and plugins."
 homepage = "https://github.com/WasmEdge/wasmedgeup"
@@ -24,7 +25,6 @@ tracing-subscriber = "0.3.23"
 url = "2.5.8"
 walkdir = "2.5.0"
 sha2 = "0.11"
-serial_test = "3.4.0"
 hex = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -51,4 +51,7 @@ default = []
 opencl = ["dep:opencl3"]
 
 [dev-dependencies]
-rstest = "0.26.1"
+serial_test = "3.4.0"
+
+[profile.dev.package."*"]
+debug = false

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -14,7 +14,7 @@ fn default_path() -> Result<PathBuf> {
 
 pub fn insufficient_permissions(path: &Path, action: &str, version: &str) -> Error {
     let system_dir = if cfg!(windows) {
-        "C\\Program Files\\WasmEdge".to_string()
+        "C:\\Program Files\\WasmEdge".to_string()
     } else {
         "/usr/local".to_string()
     };

--- a/src/commands/plugin/version.rs
+++ b/src/commands/plugin/version.rs
@@ -2,7 +2,6 @@ use std::str::FromStr;
 
 use semver::Version;
 
-#[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub enum PluginVersion {
     Name(String),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,6 @@ pub mod error;
 pub mod fs;
 pub mod http;
 pub mod prelude;
-pub mod shell_utils; // This should now point to the directory
+pub mod shell_utils;
 pub mod system;
 pub mod target;

--- a/src/system/plugins.rs
+++ b/src/system/plugins.rs
@@ -69,33 +69,3 @@ pub fn plugin_platform_key(os: &OsSpec, runtime_version: &Version) -> Result<Str
         }
     }
 }
-
-pub fn platform_key_from_specs(os: &OsSpec) -> Result<String> {
-    let arch_str = arch_to_string(&os.arch);
-    match os.os_type {
-        TargetOS::Darwin => {
-            let darwin_arch = arch_to_darwin_string(&os.arch);
-            Ok(format!("darwin_{darwin_arch}"))
-        }
-        TargetOS::Windows => Ok("windows_x86_64".to_string()),
-        TargetOS::Linux | TargetOS::Ubuntu => {
-            let distro = os.distro.as_deref().unwrap_or("").to_lowercase();
-            let version = os.version.as_deref().unwrap_or("");
-            if distro.contains("ubuntu") {
-                if version.starts_with("20.04") || version.starts_with("20") {
-                    return Ok(format!("ubuntu20_04_{arch_str}"));
-                }
-                if version.starts_with("22.04") || version.starts_with("22") {
-                    return Ok(format!("ubuntu22_04_{arch_str}"));
-                }
-            }
-            if matches!(os.libc.kind, LibcKind::Glibc) {
-                return Ok(format!("manylinux_2_28_{arch_str}"));
-            }
-            Err(Error::UnsupportedPlatform {
-                os: format!("{:?}", os.os_type),
-                arch: format!("{:?}", os.arch),
-            })
-        }
-    }
-}

--- a/tests/plugin-list-tests.rs
+++ b/tests/plugin-list-tests.rs
@@ -1,8 +1,9 @@
+use semver::Version;
 use serde_json::Value;
 use wasmedgeup::{
     api::runtime_ge_015,
     commands::plugin::list::platform_fallbacks,
-    system::{self, plugins::platform_key_from_specs},
+    system::{self, plugins::plugin_platform_key},
 };
 
 const ASSET_PREFIX: &str = "WasmEdge-plugin-";
@@ -50,11 +51,12 @@ fn test_platform_fallbacks_manylinux2014_with_new_runtime() {
 #[tokio::test]
 async fn test_github_assets_list_contains_expected_platform() {
     let spec = system::detect();
-    let platform = platform_key_from_specs(&spec.os).expect("platform key");
     let runtime = match system::toolchain::get_installed_wasmedge_version() {
         Ok(v) => v,
         Err(_) => "0.15.0".to_string(),
     };
+    let runtime_ver = Version::parse(&runtime).unwrap_or_else(|_| Version::new(0, 15, 0));
+    let platform = plugin_platform_key(&spec.os, &runtime_ver).expect("platform key");
     let url = format!("{GH_RELEASE_TAG_API}/{runtime}");
 
     let client = reqwest::Client::new();

--- a/tests/system-tests.rs
+++ b/tests/system-tests.rs
@@ -1,19 +1,24 @@
+use semver::Version;
 use wasmedgeup::system::cpu::{classify, parse_flags};
-use wasmedgeup::system::plugins::{platform_key_from_specs, plugin_platform_key};
+use wasmedgeup::system::plugins::plugin_platform_key;
 use wasmedgeup::system::{self, CpuClass, CpuFeature, LibcKind, LibcSpec, OsSpec};
 use wasmedgeup::target::{TargetArch, TargetOS};
+
+fn probe_version() -> Version {
+    Version::parse("0.15.0").expect("0.15.0 is valid semver")
+}
 
 #[test]
 fn test_platform_key_detect_non_empty() {
     let spec = system::detect();
-    let key = platform_key_from_specs(&spec.os).expect("platform key");
+    let key = plugin_platform_key(&spec.os, &probe_version()).expect("platform key");
     assert!(!key.is_empty());
 }
 
 #[test]
 fn test_platform_key_has_known_arch_suffix() {
     let spec = system::detect();
-    let key = platform_key_from_specs(&spec.os).expect("platform key");
+    let key = plugin_platform_key(&spec.os, &probe_version()).expect("platform key");
     assert!(
         key.ends_with("x86_64") || key.ends_with("aarch64") || key.ends_with("arm64"),
         "unexpected platform key suffix: {key}"
@@ -23,10 +28,8 @@ fn test_platform_key_has_known_arch_suffix() {
 #[test]
 fn test_platform_key_prefix_is_reasonable() {
     let spec = system::detect();
-    let key = platform_key_from_specs(&spec.os).expect("platform key");
-    let ok_prefix = key.starts_with("ubuntu20_04_")
-        || key.starts_with("ubuntu22_04_")
-        || key.starts_with("manylinux2014_")
+    let key = plugin_platform_key(&spec.os, &probe_version()).expect("platform key");
+    let ok_prefix = key.starts_with("manylinux2014_")
         || key.starts_with("manylinux_2_28_")
         || key.starts_with("darwin_")
         || key.starts_with("windows_");


### PR DESCRIPTION
## Which GitHub issue does this PR close?

N/A — cleanup items surfaced during a self-initiated refactor review.

## Why is this needed?

A thorough project review surfaced a handful of low-risk hygiene issues
in `Cargo.toml` and the source tree. Landing them first clears warnings
and project-guideline gaps before larger refactor PRs build on top.

## What does this PR change?

- **`Cargo.toml`**:
  - Adds `rust-version = "1.85"` (MSRV declaration — CI already tests
    on stable/beta, this just documents the floor).
  - Moves `serial_test` from `[dependencies]` to `[dev-dependencies]`;
    it's only referenced by `tests/shell_test.rs`.
  - Drops unused `rstest` dev-dep (never imported in any test).
  - Adds `[profile.dev.package."*"] debug = false` per the project's
    CLAUDE.md guidance (skips debug info for deps in dev builds).
- **Typo fix** in `src/commands/mod.rs`: the Windows install-dir hint
  was missing its drive-letter colon (`C\Program Files\WasmEdge` →
  `C:\Program Files\WasmEdge`).
- **Stale annotation** removed: `#[allow(dead_code)]` on `PluginVersion`
  in `src/commands/plugin/version.rs` — the enum is actually used by
  the plugin install/remove CLI parsers.
- **Stale comment** removed from `src/lib.rs:8`.
- **Dead code** removed: `platform_key_from_specs` in
  `src/system/plugins.rs`. It lived in parallel with
  `plugin_platform_key` (runtime-version-aware) and was only
  referenced from tests. The tests in `tests/system-tests.rs` and
  `tests/plugin-list-tests.rs` now use `plugin_platform_key` with an
  explicit runtime version so they exercise the production code path.

No behavior change.

## How has this been tested?

- `cargo fmt --all --check` ✅
- `cargo clippy --all --all-features --tests -- -D warnings` ✅
- `cargo test` ✅ — all tests pass, including the updated
  `tests/system-tests.rs` (3 tests migrated to `plugin_platform_key`)
  and `tests/plugin-list-tests.rs` (1 test migrated).

## Anything else?

This is the first of a series of small, incremental refactor PRs. Each
subsequent PR will rebase onto `master` after this lands.