### PR TITLE
refactor: centralize URL and timeout constants into constants module

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -6,6 +6,10 @@ use std::{
 };
 
 use crate::{
+    constants::{
+        CHECKSUM_FILE_NAME, DEFAULT_CONNECT_TIMEOUT_SECS, DEFAULT_REQUEST_TIMEOUT_SECS,
+        DOWNLOAD_BUFFER_SIZE, WASMEDGE_GIT_URL, WASMEDGE_RELEASE_BASE_URL,
+    },
     http::HttpClientConfig,
     prelude::*,
     target::{TargetArch, TargetOS},
@@ -33,12 +37,6 @@ pub struct WasmEdgeApiClient {
     pub request_timeout: u64,
 }
 
-const WASM_EDGE_GIT_URL: &str = "https://github.com/WasmEdge/WasmEdge.git";
-const WASM_EDGE_RELEASE_ASSET_BASE_URL: &str =
-    "https://github.com/WasmEdge/WasmEdge/releases/download";
-const CHECKSUM_FILE_NAME: &str = "SHA256SUM";
-const BUFFER_SIZE: usize = 8 * 1024; // 8KB
-
 impl WasmEdgeApiClient {
     fn http_client(&self) -> Result<Client> {
         HttpClientConfig::new()
@@ -48,12 +46,12 @@ impl WasmEdgeApiClient {
     }
 
     pub fn releases(&self, filter: ReleasesFilter, num_releases: usize) -> Result<Vec<Version>> {
-        let releases = releases::get_all(WASM_EDGE_GIT_URL, filter)?;
+        let releases = releases::get_all(WASMEDGE_GIT_URL, filter)?;
         Ok(releases.into_iter().take(num_releases).collect())
     }
 
     pub fn latest_release(&self) -> Result<Version> {
-        let releases = releases::get_all(WASM_EDGE_GIT_URL, ReleasesFilter::Stable)?;
+        let releases = releases::get_all(WASMEDGE_GIT_URL, ReleasesFilter::Stable)?;
         releases.into_iter().next().ok_or(Error::Unknown)
     }
 
@@ -89,8 +87,8 @@ impl WasmEdgeApiClient {
     }
 
     pub async fn get_release_checksum(&self, version: &Version, asset: &Asset) -> Result<String> {
-        let mut url = Url::parse(WASM_EDGE_RELEASE_ASSET_BASE_URL)
-            .expect("WASM_EDGE_RELEASE_ASSET_BASE_URL must be a valid URL");
+        let mut url = Url::parse(WASMEDGE_RELEASE_BASE_URL)
+            .expect("WASMEDGE_RELEASE_BASE_URL must be a valid URL");
 
         url.path_segments_mut()
             .expect("base is valid URL")
@@ -153,7 +151,7 @@ impl WasmEdgeApiClient {
 
     pub async fn verify_file_checksum(file: &mut std::fs::File, expected: &str) -> Result<()> {
         let mut hasher = Sha256::new();
-        let mut buffer = vec![0; BUFFER_SIZE];
+        let mut buffer = vec![0; DOWNLOAD_BUFFER_SIZE];
 
         loop {
             let count = file.read(&mut buffer)?;
@@ -179,8 +177,8 @@ impl WasmEdgeApiClient {
 impl WasmEdgeApiClient {
     pub fn new() -> Self {
         Self {
-            connect_timeout: 15, // 15 seconds for connection
-            request_timeout: 90, // 90 seconds for request
+            connect_timeout: DEFAULT_CONNECT_TIMEOUT_SECS,
+            request_timeout: DEFAULT_REQUEST_TIMEOUT_SECS,
         }
     }
 
@@ -254,8 +252,8 @@ impl Asset {
     }
 
     pub fn url(&self) -> Result<Url> {
-        let mut url = Url::parse(WASM_EDGE_RELEASE_ASSET_BASE_URL)
-            .expect("WASM_EDGE_RELEASE_ASSET_BASE_URL must be a valid URL");
+        let mut url = Url::parse(WASMEDGE_RELEASE_BASE_URL)
+            .expect("WASMEDGE_RELEASE_BASE_URL must be a valid URL");
 
         url.path_segments_mut()
             .expect("base is valid URL")

--- a/src/commands/plugin/install.rs
+++ b/src/commands/plugin/install.rs
@@ -4,6 +4,7 @@ use clap::{value_parser, Args};
 use tokio::fs;
 use walkdir::WalkDir;
 
+use crate::constants::WASMEDGE_RELEASE_BASE_URL;
 use crate::system::plugins::plugin_platform_key;
 use crate::{
     cli::{CommandContext, CommandExecutor},
@@ -16,8 +17,6 @@ use crate::{
 
 use super::utils::find_plugin_shared_objects;
 use super::version::PluginVersion;
-
-const GH_RELEASE_DOWNLOAD_BASE: &str = "https://github.com/WasmEdge/WasmEdge/releases/download";
 
 #[derive(Debug, Args)]
 pub struct PluginInstallArgs {
@@ -112,7 +111,7 @@ impl CommandExecutor for PluginInstallArgs {
             let ext = if is_windows { "zip" } else { "tar.gz" };
             let url = format!(
                 "{base}/{ver}/WasmEdge-plugin-{name}-{ver}-{os_key}.{ext}",
-                base = GH_RELEASE_DOWNLOAD_BASE,
+                base = WASMEDGE_RELEASE_BASE_URL,
                 name = name,
                 ver = pver,
                 os_key = os_key,

--- a/src/commands/plugin/list.rs
+++ b/src/commands/plugin/list.rs
@@ -1,5 +1,6 @@
 use crate::api::runtime_ge_015;
 use crate::cli::{CommandContext, CommandExecutor};
+use crate::constants::{WASMEDGE_GH_RELEASE_TAG_API, WASMEDGE_RELEASE_BASE_URL};
 use crate::prelude::*;
 use crate::system;
 use crate::system::plugins::plugin_platform_key;
@@ -9,8 +10,6 @@ use std::cmp::Ordering;
 use std::collections::HashSet;
 
 const UA: &str = "wasmedgeup";
-const GH_RELEASE_TAG_API: &str = "https://api.github.com/repos/WasmEdge/WasmEdge/releases/tags";
-const GH_RELEASE_DOWNLOAD_BASE: &str = "https://github.com/WasmEdge/WasmEdge/releases/download";
 const ASSET_PREFIX: &str = "WasmEdge-plugin-";
 const TAR_GZ: &str = ".tar.gz";
 const ZIP: &str = ".zip";
@@ -133,10 +132,10 @@ impl CommandExecutor for PluginListArgs {
                 for probe in probes {
                     for plat in &platform_candidates {
                         let url_targz = format!(
-                            "{GH_RELEASE_DOWNLOAD_BASE}/{runtime}/{ASSET_PREFIX}{probe}-{runtime}-{plat}{TAR_GZ}"
+                            "{WASMEDGE_RELEASE_BASE_URL}/{runtime}/{ASSET_PREFIX}{probe}-{runtime}-{plat}{TAR_GZ}"
                         );
                         let url_zip = format!(
-                            "{GH_RELEASE_DOWNLOAD_BASE}/{runtime}/{ASSET_PREFIX}{probe}-{runtime}-{plat}{ZIP}"
+                            "{WASMEDGE_RELEASE_BASE_URL}/{runtime}/{ASSET_PREFIX}{probe}-{runtime}-{plat}{ZIP}"
                         );
                         let available = head_ok(&url_targz).await || head_ok(&url_zip).await;
                         rows.push(Row {
@@ -251,7 +250,7 @@ struct AssetInfo {
 }
 
 async fn fetch_release_assets(tag: &str) -> Result<Vec<AssetInfo>, ()> {
-    let url = format!("{GH_RELEASE_TAG_API}/{tag}");
+    let url = format!("{WASMEDGE_GH_RELEASE_TAG_API}/{tag}");
     let client = reqwest::Client::new();
     let resp = client
         .get(&url)

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,0 +1,29 @@
+//! Project-wide constants shared by the api, http, and command modules.
+//!
+//! Keeping these in one place prevents drift between parallel code paths
+//! (for example, the runtime installer and the plugin subsystem both hit
+//! the same GitHub release endpoints).
+
+/// Git URL for the WasmEdge project, used by `api::releases` to enumerate
+/// released versions via git refs (avoids a GitHub API rate limit hit).
+pub const WASMEDGE_GIT_URL: &str = "https://github.com/WasmEdge/WasmEdge.git";
+
+/// Base URL for downloading released WasmEdge runtime and plugin archives.
+pub const WASMEDGE_RELEASE_BASE_URL: &str =
+    "https://github.com/WasmEdge/WasmEdge/releases/download";
+
+/// Base URL for the GitHub REST API endpoint that lists release metadata by tag.
+pub const WASMEDGE_GH_RELEASE_TAG_API: &str =
+    "https://api.github.com/repos/WasmEdge/WasmEdge/releases/tags";
+
+/// File name of the SHA256 checksum file published alongside runtime releases.
+pub const CHECKSUM_FILE_NAME: &str = "SHA256SUM";
+
+/// Default connection timeout (seconds) for all HTTP calls.
+pub const DEFAULT_CONNECT_TIMEOUT_SECS: u64 = 15;
+
+/// Default request/read timeout (seconds) for all HTTP calls.
+pub const DEFAULT_REQUEST_TIMEOUT_SECS: u64 = 90;
+
+/// Buffer size used when streaming downloads and computing checksums.
+pub const DOWNLOAD_BUFFER_SIZE: usize = 8 * 1024;

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,3 +1,4 @@
+use crate::constants::{DEFAULT_CONNECT_TIMEOUT_SECS, DEFAULT_REQUEST_TIMEOUT_SECS};
 use crate::prelude::*;
 use reqwest::Client;
 use std::time::Duration;
@@ -14,8 +15,8 @@ pub struct HttpClientConfig {
 impl Default for HttpClientConfig {
     fn default() -> Self {
         Self {
-            connect_timeout: 15, // 15 seconds for connection
-            request_timeout: 90, // 90 seconds for request
+            connect_timeout: DEFAULT_CONNECT_TIMEOUT_SECS,
+            request_timeout: DEFAULT_REQUEST_TIMEOUT_SECS,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod api;
 pub mod cli;
 pub mod commands;
+pub mod constants;
 pub mod error;
 pub mod fs;
 pub mod http;


### PR DESCRIPTION
## Which GitHub issue does this PR close?

N/A — follow-up to #253. Part of an incremental refactor series.

## Why is this needed?

Three modules independently re-declared the same upstream URLs and timeout literals:

- `src/api/mod.rs` had `WASM_EDGE_GIT_URL`, `WASM_EDGE_RELEASE_ASSET_BASE_URL`, `CHECKSUM_FILE_NAME`, `BUFFER_SIZE`, plus inline `15` / `90` second timeouts in `WasmEdgeApiClient::new`.
- `src/http.rs` had its own inline `15` / `90` timeout literals in `HttpClientConfig::default`.
- `src/commands/plugin/install.rs` and `src/commands/plugin/list.rs` each declared their own copy of the GitHub releases base URL plus a separate GitHub REST API base.

The drift wasn't theoretical: if a reviewer wanted to bump the request timeout or change the release host, they'd have to find and update three different definitions. Consolidating these into a single module also clears the way for the next refactor in the series, which folds the plugin subsystem's HTTP plumbing back into `WasmEdgeApiClient` and depends on the constants being shared.

## What does this PR change?

- **New module** `src/constants.rs` declares:
  - `WASMEDGE_GIT_URL` — git remote for release enumeration
  - `WASMEDGE_RELEASE_BASE_URL` — base for `releases/download/...`
  - `WASMEDGE_GH_RELEASE_TAG_API` — GitHub REST API base for plugin asset metadata
  - `CHECKSUM_FILE_NAME` — `SHA256SUM`
  - `DEFAULT_CONNECT_TIMEOUT_SECS = 15`
  - `DEFAULT_REQUEST_TIMEOUT_SECS = 90`
  - `DOWNLOAD_BUFFER_SIZE = 8 * 1024`
- **Renames** `WASM_EDGE_GIT_URL` → `WASMEDGE_GIT_URL` and `WASM_EDGE_RELEASE_ASSET_BASE_URL` → `WASMEDGE_RELEASE_BASE_URL` and `BUFFER_SIZE` → `DOWNLOAD_BUFFER_SIZE` for naming consistency with the new module's prefix.
- **`HttpClientConfig::default`** now reads `DEFAULT_CONNECT_TIMEOUT_SECS` / `DEFAULT_REQUEST_TIMEOUT_SECS` instead of hardcoded `15` / `90`. Same for `WasmEdgeApiClient::new`.
- **`src/commands/plugin/install.rs`** drops its local `GH_RELEASE_DOWNLOAD_BASE` constant and imports `WASMEDGE_RELEASE_BASE_URL` from the constants module.
- **`src/commands/plugin/list.rs`** drops its local `GH_RELEASE_TAG_API` and `GH_RELEASE_DOWNLOAD_BASE` constants in favor of the shared constants.

No runtime behavior change — the URLs and timeouts are byte-identical to before. This is pure deduplication.

## How has this been tested?

- `cargo fmt --all --check` ✅
- `cargo clippy --all --all-features --tests -- -D warnings` ✅
- `cargo test` ✅ — full suite passes

## Anything else?

This is the second of a series of small, incremental refactor PRs.