### PR TITLE
chore: bump deps for fixing RUSTSEC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1890,9 +1890,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",


### PR DESCRIPTION
## Which GitHub issue does this PR close?

Closes the security advisory surfaced by Dependabot alert #15.

## Why is this needed?

GitHub flagged `rustls-webpki < 0.103.13` (currently pinned to `0.103.12` in `Cargo.lock`) as vulnerable to GHSA-82j2-j2ch-gfr8 — a high-severity DoS where a malformed CRL BIT STRING can cause a panic during certificate validation. We pull `rustls-webpki` in transitively via reqwest's TLS stack, so any code path that initiates an HTTPS request (which is most of `wasmedgeup`) is exposed.

## What does this PR change?

A targeted `cargo update -p rustls-webpki --precise 0.103.13` so only the affected crate moves; other transitive deps stay where Dependabot last bumped them. Diff is the version line and the registry checksum on a single `[[package]]` entry in `Cargo.lock`.

No changes to `Cargo.toml`, no source changes.

## How has this been tested?

- `cargo build --release` ✅
- `cargo fmt --all --check` ✅
- `cargo clippy --all --all-features --tests -- -D warnings` ✅
- `cargo test` ✅ — full suite passes

## Anything else?

GHSA-82j2-j2ch-gfr8 is a panic-on-malformed-input bug, so the practical risk is limited to a connection-level abort if a peer serves a crafted CRL — not RCE — but it's classed high because reqwest clients with no recovery wrapper would die. Worth landing before continuing the refactor stack.