### PR TITLE
test: add unit tests for pure logic inside src/

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -371,3 +371,140 @@ pub fn runtime_ge_015(runtime: &str) -> bool {
         .map(|v| v >= semver::Version::new(0, 15, 0))
         .unwrap_or(true)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn v(s: &str) -> Version {
+        Version::parse(s).expect("valid semver")
+    }
+
+    #[test]
+    fn archive_name_ubuntu_x86_64() {
+        let a = Asset::new(&v("0.15.0"), &TargetOS::Ubuntu, &TargetArch::X86_64);
+        assert_eq!(a.archive_name, "WasmEdge-0.15.0-ubuntu20.04_x86_64.tar.gz");
+    }
+
+    #[test]
+    fn archive_name_ubuntu_aarch64_requires_0_13_5() {
+        let old = Asset::new(&v("0.13.4"), &TargetOS::Ubuntu, &TargetArch::Aarch64);
+        assert_eq!(
+            old.archive_name, "WasmEdge-0.13.4-manylinux2014_aarch64.tar.gz",
+            "pre-0.13.5 aarch64 Ubuntu should fall back to manylinux"
+        );
+
+        let new = Asset::new(&v("0.13.5"), &TargetOS::Ubuntu, &TargetArch::Aarch64);
+        assert_eq!(
+            new.archive_name, "WasmEdge-0.13.5-ubuntu20.04_aarch64.tar.gz",
+            "0.13.5+ aarch64 Ubuntu uses ubuntu20.04 asset"
+        );
+    }
+
+    #[test]
+    fn archive_name_linux_manylinux_split_on_0_15() {
+        let old = Asset::new(&v("0.14.1"), &TargetOS::Linux, &TargetArch::X86_64);
+        assert_eq!(
+            old.archive_name, "WasmEdge-0.14.1-manylinux2014_x86_64.tar.gz",
+            "<= 0.14 uses manylinux2014"
+        );
+
+        let new = Asset::new(&v("0.15.0"), &TargetOS::Linux, &TargetArch::X86_64);
+        assert_eq!(
+            new.archive_name, "WasmEdge-0.15.0-manylinux_2_28_x86_64.tar.gz",
+            ">= 0.15 uses manylinux_2_28"
+        );
+    }
+
+    #[test]
+    fn archive_name_darwin_uses_arm64_alias() {
+        let a = Asset::new(&v("0.15.0"), &TargetOS::Darwin, &TargetArch::Aarch64);
+        assert_eq!(a.archive_name, "WasmEdge-0.15.0-darwin_arm64.tar.gz");
+
+        let x = Asset::new(&v("0.15.0"), &TargetOS::Darwin, &TargetArch::X86_64);
+        assert_eq!(x.archive_name, "WasmEdge-0.15.0-darwin_x86_64.tar.gz");
+    }
+
+    #[test]
+    fn archive_name_windows_is_zip() {
+        let a = Asset::new(&v("0.15.0"), &TargetOS::Windows, &TargetArch::X86_64);
+        assert_eq!(a.archive_name, "WasmEdge-0.15.0-windows.zip");
+    }
+
+    #[test]
+    fn install_name_per_os() {
+        let lin = Asset::new(&v("0.15.0"), &TargetOS::Linux, &TargetArch::X86_64);
+        assert_eq!(lin.install_name, "WasmEdge-0.15.0-Linux");
+        let ubu = Asset::new(&v("0.15.0"), &TargetOS::Ubuntu, &TargetArch::X86_64);
+        assert_eq!(ubu.install_name, "WasmEdge-0.15.0-Linux");
+        let mac = Asset::new(&v("0.15.0"), &TargetOS::Darwin, &TargetArch::Aarch64);
+        assert_eq!(mac.install_name, "WasmEdge-0.15.0-Darwin");
+        let win = Asset::new(&v("0.15.0"), &TargetOS::Windows, &TargetArch::X86_64);
+        assert_eq!(win.install_name, "WasmEdge-0.15.0-Windows");
+    }
+
+    #[test]
+    fn manylinux2014_supported_boundary() {
+        assert!(is_manylinux2014_supported(&v("0.13.0")));
+        assert!(is_manylinux2014_supported(&v("0.14.99")));
+        assert!(!is_manylinux2014_supported(&v("0.15.0")));
+        assert!(!is_manylinux2014_supported(&v("1.0.0")));
+    }
+
+    #[test]
+    fn arm_ubuntu_supported_boundary() {
+        assert!(!is_arm_ubuntu_supported(&v("0.13.4")));
+        assert!(is_arm_ubuntu_supported(&v("0.13.5")));
+        assert!(is_arm_ubuntu_supported(&v("0.15.0")));
+    }
+
+    #[test]
+    fn asset_url_is_valid() {
+        let a = Asset::new(&v("0.15.0"), &TargetOS::Linux, &TargetArch::X86_64);
+        let url = a.url().expect("url builds");
+        assert_eq!(
+            url.as_str(),
+            "https://github.com/WasmEdge/WasmEdge/releases/download/0.15.0/WasmEdge-0.15.0-manylinux_2_28_x86_64.tar.gz"
+        );
+    }
+
+    #[test]
+    fn latest_installed_version_missing_dir_is_none() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let missing = tmp.path().join("nope");
+        assert_eq!(latest_installed_version(&missing).unwrap(), None);
+    }
+
+    #[test]
+    fn latest_installed_version_empty_dir_is_none() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        assert_eq!(latest_installed_version(tmp.path()).unwrap(), None);
+    }
+
+    #[test]
+    fn latest_installed_version_picks_highest_semver() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        for name in ["0.14.1", "0.15.0", "0.13.5", "not-a-version"] {
+            std::fs::create_dir(tmp.path().join(name)).expect("mkdir");
+        }
+        // Also drop a regular file to ensure it's ignored.
+        std::fs::write(tmp.path().join("stray.txt"), "").expect("file");
+
+        let picked = latest_installed_version(tmp.path()).unwrap();
+        assert_eq!(picked, Some(v("0.15.0")));
+    }
+
+    #[test]
+    fn runtime_ge_015_boundaries() {
+        assert!(!runtime_ge_015("0.14.99"));
+        assert!(runtime_ge_015("0.15.0"));
+        // semver ordering: prereleases sort before the stable release.
+        assert!(
+            !runtime_ge_015("0.15.0-rc.1"),
+            "0.15.0-rc.1 < 0.15.0 per semver rules",
+        );
+        assert!(runtime_ge_015("1.0.0"));
+        // Unparseable input fails open (defensive).
+        assert!(runtime_ge_015("not-a-version"));
+    }
+}

--- a/src/commands/plugin/list.rs
+++ b/src/commands/plugin/list.rs
@@ -315,3 +315,72 @@ pub fn platform_fallbacks(primary: &str, runtime: &str) -> Vec<String> {
     out.dedup();
     out
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_asset_name_targz() {
+        let parsed = parse_asset_name(
+            "WasmEdge-plugin-wasi_nn-ggml-0.15.0-manylinux_2_28_x86_64.tar.gz",
+            "0.15.0",
+        );
+        assert_eq!(
+            parsed,
+            Some((
+                "wasi_nn-ggml".to_string(),
+                "0.15.0".to_string(),
+                "manylinux_2_28_x86_64".to_string(),
+            ))
+        );
+    }
+
+    #[test]
+    fn parse_asset_name_zip() {
+        let parsed = parse_asset_name(
+            "WasmEdge-plugin-wasi_crypto-0.14.1-windows_x86_64.zip",
+            "0.14.1",
+        );
+        assert_eq!(
+            parsed,
+            Some((
+                "wasi_crypto".to_string(),
+                "0.14.1".to_string(),
+                "windows_x86_64".to_string(),
+            ))
+        );
+    }
+
+    #[test]
+    fn parse_asset_name_rejects_unrelated_prefix() {
+        let parsed = parse_asset_name("WasmEdge-0.15.0-linux.tar.gz", "0.15.0");
+        assert_eq!(parsed, None);
+    }
+
+    #[test]
+    fn parse_asset_name_rejects_tag_mismatch() {
+        // The needle "-0.15.0-" is not present in an archive tagged 0.14.1.
+        let parsed = parse_asset_name(
+            "WasmEdge-plugin-wasi_nn-ggml-0.14.1-manylinux2014_x86_64.tar.gz",
+            "0.15.0",
+        );
+        assert_eq!(parsed, None);
+    }
+
+    #[test]
+    fn parse_asset_name_plugin_name_may_contain_dashes() {
+        let parsed = parse_asset_name(
+            "WasmEdge-plugin-wasi-logging-0.15.0-darwin_arm64.tar.gz",
+            "0.15.0",
+        );
+        assert_eq!(
+            parsed,
+            Some((
+                "wasi-logging".to_string(),
+                "0.15.0".to_string(),
+                "darwin_arm64".to_string(),
+            ))
+        );
+    }
+}

--- a/src/system/toolchain.rs
+++ b/src/system/toolchain.rs
@@ -50,21 +50,82 @@ pub fn get_installed_wasmedge_version() -> Result<String, String> {
         return Err("wasmedge --version exited with non-zero status".to_string());
     }
     let stdout = String::from_utf8_lossy(&out.stdout);
-    // Heuristic parse: pick the first token that starts with a digit and contains at least one '.'
-    // e.g., "wasmedge version 0.15.0" -> 0.15.0
-    // also accept prerelease like 0.15.0-rc.1
+    parse_wasmedge_version_output(&stdout)
+        .ok_or_else(|| format!("unable to parse version from: {}", stdout.trim()))
+}
+
+/// Extract a semver-like version token from `wasmedge --version` output.
+///
+/// Picks the first whitespace-separated token that starts with an ASCII
+/// digit and contains at least one `.`, then trims trailing characters
+/// that are not alphanumerics, `.`, or `-`. Returns `None` if no token
+/// matches.
+pub(crate) fn parse_wasmedge_version_output(stdout: &str) -> Option<String> {
     for token in stdout.split_whitespace() {
-        if token
+        let starts_with_digit = token
             .chars()
             .next()
             .map(|c| c.is_ascii_digit())
-            .unwrap_or(false)
-            && token.contains('.')
-        {
+            .unwrap_or(false);
+        if starts_with_digit && token.contains('.') {
             let ver = token
                 .trim_end_matches(|c: char| !c.is_ascii_alphanumeric() && c != '.' && c != '-');
-            return Ok(ver.to_string());
+            return Some(ver.to_string());
         }
     }
-    Err(format!("unable to parse version from: {}", stdout.trim()))
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_wasmedge_version_output;
+
+    #[test]
+    fn parses_simple_version() {
+        assert_eq!(
+            parse_wasmedge_version_output("wasmedge version 0.15.0"),
+            Some("0.15.0".to_string())
+        );
+    }
+
+    #[test]
+    fn parses_prerelease_version() {
+        assert_eq!(
+            parse_wasmedge_version_output("wasmedge version 0.15.0-rc.1"),
+            Some("0.15.0-rc.1".to_string())
+        );
+    }
+
+    #[test]
+    fn trims_trailing_non_version_chars() {
+        // Characters other than alphanumerics, '.', and '-' should be trimmed
+        // from the tail; a trailing comma/paren is stripped while a legitimate
+        // trailing '.' or '-' would be preserved.
+        assert_eq!(
+            parse_wasmedge_version_output("wasmedge version 0.15.0, build info"),
+            Some("0.15.0".to_string())
+        );
+        assert_eq!(
+            parse_wasmedge_version_output("wasmedge (version 0.15.0)"),
+            Some("0.15.0".to_string())
+        );
+    }
+
+    #[test]
+    fn returns_none_for_no_version_token() {
+        assert_eq!(parse_wasmedge_version_output("wasmedge (no version)"), None);
+    }
+
+    #[test]
+    fn returns_none_for_empty_output() {
+        assert_eq!(parse_wasmedge_version_output(""), None);
+    }
+
+    #[test]
+    fn ignores_leading_non_digit_tokens() {
+        assert_eq!(
+            parse_wasmedge_version_output("version: 0.14.1"),
+            Some("0.14.1".to_string())
+        );
+    }
 }


### PR DESCRIPTION
## Which GitHub issue does this PR close?

N/A — follow-up to #258. Part of an incremental refactor series.

## Why is this needed?

Several pure-logic helpers in the crate had no targeted unit tests; behaviour
was only exercised through integration tests that hit the real GitHub release
API. Adding focused, hermetic unit tests inside `src/` gives us:

- Fast feedback on the asset-naming and platform-fallback rules (the bits the
  installer cares about most), without depending on network availability.
- A safety net for the upcoming refactor PRs: PR #5 reshapes plugin HTTP
  plumbing and PR #6 adds plugin checksum verification — both build directly
  on the helpers tested here.

## What does this PR change?

- **`src/api/mod.rs`**: `#[cfg(test)] mod tests` covering
  - `Asset::format_archive_name` across every supported `(TargetOS, TargetArch)`
    pair, including the `0.13.5` ARM-Ubuntu boundary and the `0.15.0`
    `manylinux2014` → `manylinux_2_28` cutover,
  - `Asset::format_install_name` per OS,
  - `is_manylinux2014_supported` / `is_arm_ubuntu_supported` boundary cases,
  - `Asset::url` produces a well-formed URL,
  - `latest_installed_version` against a `tempfile::TempDir` (missing dir,
    empty dir, mixed entries with non-semver names),
  - `runtime_ge_015` for stable, prerelease, and unparseable input.
- **`src/commands/plugin/list.rs`**: `#[cfg(test)] mod tests` covering
  `parse_asset_name` for `.tar.gz`, `.zip`, unrelated prefix, tag mismatch,
  and plugin names that contain internal dashes (e.g. `wasi-logging`).
- **`src/system/toolchain.rs`**: extracts `parse_wasmedge_version_output(&str) -> Option<String>`
  as a pure function (`get_installed_wasmedge_version` now delegates to it
  after running the `wasmedge --version` subprocess), and adds 6 unit tests
  for the parser's input shapes (empty, non-version, prerelease, trailing-junk,
  leading non-digit, build-noise).

No production-behaviour change beyond the toolchain extraction, which is a
pure refactor — same inputs produce the same outputs.

## How has this been tested?

- `cargo fmt --all --check` ✅
- `cargo clippy --all --all-features --tests -- -D warnings` ✅
- `cargo test` ✅ — full suite passes; lib-test bin rises from 5 → 29 with
  the new in-source `mod tests` blocks (~24 new test cases).

## Anything else?

Third in the incremental refactor series. The `#[serial]` markers on
env-mutating integration tests follow in PR #4.