### PR TITLE
test: serialize env-mutating integration tests

### DIFF
--- a/tests/install_test.rs
+++ b/tests/install_test.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
 use semver::Version as SemVersion;
+use serial_test::serial;
 use tempfile::{tempdir, TempDir};
 use wasmedgeup::system;
 use wasmedgeup::{
@@ -75,6 +76,7 @@ async fn execute_install_test(
 }
 
 #[tokio::test]
+#[serial]
 async fn test_install_latest_version() {
     let tmpdir = tempdir().unwrap();
     let install_dir = tmpdir.path().join("install_target");
@@ -92,6 +94,7 @@ async fn test_install_latest_version() {
 }
 
 #[tokio::test]
+#[serial]
 async fn test_install_prerelease_version() {
     let tmpdir = tempdir().unwrap();
     let install_dir = tmpdir.path().join("install_target");

--- a/tests/plugin_install_test.rs
+++ b/tests/plugin_install_test.rs
@@ -10,6 +10,7 @@ use wasmedgeup::{
 };
 
 mod test_utils;
+use serial_test::serial;
 use test_utils::setup_test_environment;
 
 async fn execute_runtime_install(version: String, install_dir: &Path, tmpdir: &TempDir) {
@@ -65,6 +66,7 @@ use wasmedgeup::system::plugins::plugin_platform_key;
 use wasmedgeup::target::TargetOS;
 
 #[tokio::test]
+#[serial]
 async fn test_plugin_install_latest_runtime() {
     let tmpdir = tempdir().unwrap();
     let install_dir = tmpdir.path().join("install_target");

--- a/tests/plugin_remove_tests.rs
+++ b/tests/plugin_remove_tests.rs
@@ -1,5 +1,6 @@
 use std::path::{Path, PathBuf};
 
+use serial_test::serial;
 use wasmedgeup::{
     api::WasmEdgeApiClient,
     cli::{CommandContext, CommandExecutor},
@@ -92,6 +93,7 @@ async fn setup_mock_runtime_with_plugins(root: &Path, version: &str, plugins: &[
 }
 
 #[tokio::test]
+#[serial]
 async fn test_plugin_remove_single() {
     let (_tmp, home) = test_utils::setup_test_environment();
     let version = "0.14.1";
@@ -116,6 +118,7 @@ async fn test_plugin_remove_single() {
 }
 
 #[tokio::test]
+#[serial]
 async fn test_plugin_remove_multiple_and_cleanup_empty_dir() {
     let (_tmp, home) = test_utils::setup_test_environment();
     let version = "0.15.0";
@@ -147,6 +150,7 @@ async fn test_plugin_remove_multiple_and_cleanup_empty_dir() {
 }
 
 #[tokio::test]
+#[serial]
 async fn test_plugin_remove_nonexistent_is_noop() {
     let (_tmp, home) = test_utils::setup_test_environment();
     let version = "0.14.1";
@@ -167,6 +171,7 @@ async fn test_plugin_remove_nonexistent_is_noop() {
 }
 
 #[tokio::test]
+#[serial]
 async fn test_plugin_remove_when_no_plugin_dir() {
     let (_tmp, home) = test_utils::setup_test_environment();
     let version = "0.14.1";

--- a/tests/remove_test.rs
+++ b/tests/remove_test.rs
@@ -1,5 +1,6 @@
 use std::path::Path;
 
+use serial_test::serial;
 use wasmedgeup::{
     api::{latest_installed_version, WasmEdgeApiClient},
     cli::{CommandContext, CommandExecutor},
@@ -10,6 +11,7 @@ use wasmedgeup::{
 mod test_utils;
 
 #[tokio::test]
+#[serial]
 async fn test_remove_single_version() {
     let (_tempdir, test_home) = test_utils::setup_test_environment();
 
@@ -32,6 +34,7 @@ async fn test_remove_single_version() {
 }
 
 #[tokio::test]
+#[serial]
 async fn test_remove_multiple_versions() {
     let (_tempdir, test_home) = test_utils::setup_test_environment();
 
@@ -87,6 +90,7 @@ async fn test_remove_multiple_versions() {
 }
 
 #[tokio::test]
+#[serial]
 async fn test_remove_all_versions() {
     let (_tempdir, test_home) = test_utils::setup_test_environment();
 
@@ -115,6 +119,7 @@ async fn test_remove_all_versions() {
 }
 
 #[tokio::test]
+#[serial]
 async fn test_remove_nonexistent_version() {
     let (_tempdir, test_home) = test_utils::setup_test_environment();
 

--- a/tests/use_test.rs
+++ b/tests/use_test.rs
@@ -1,4 +1,6 @@
 use std::path::Path;
+
+use serial_test::serial;
 use wasmedgeup::{
     api::{releases, ReleasesFilter, WasmEdgeApiClient},
     cli::{CommandContext, CommandExecutor},
@@ -10,6 +12,7 @@ mod test_utils;
 const WASM_EDGE_GIT_URL: &str = "https://github.com/WasmEdge/WasmEdge.git";
 
 #[tokio::test]
+#[serial]
 async fn test_use_version() {
     let (_tempdir, test_home) = test_utils::setup_test_environment();
 
@@ -48,6 +51,7 @@ async fn test_use_version() {
 }
 
 #[tokio::test]
+#[serial]
 async fn test_use_latest_version() {
     let (_tempdir, test_home) = test_utils::setup_test_environment();
 
@@ -84,6 +88,7 @@ async fn test_use_latest_version() {
 }
 
 #[tokio::test]
+#[serial]
 async fn test_use_nonexistent_version() {
     let (_tempdir, test_home) = test_utils::setup_test_environment();
 


### PR DESCRIPTION
## Which GitHub issue does this PR close?

N/A — follow-up to #262. Part of an incremental refactor series.

## Why is this needed?

Every integration test that calls `tests/test_utils.rs::setup_test_environment` mutates the process's `HOME` / `ZDOTDIR` / `USERPROFILE` env vars to point at a tempdir. Until now only `tests/shell_test.rs` used `#[serial]`, so other test functions in the same binary could race on that shared env state and see each other's tempdir paths during parallel execution. Symptoms would be intermittent failures where one test's symlinks land in another test's mock home — hard to reproduce locally on a fast machine, but a real risk under CI load.

## What does this PR change?

Annotates every `#[tokio::test]` that calls `setup_test_environment` with `#[serial]` and adds `use serial_test::serial;` to the file. Five test binaries gain the marker:

- `tests/install_test.rs` (2 tests)
- `tests/use_test.rs` (3 tests)
- `tests/remove_test.rs` (4 tests)
- `tests/plugin_install_test.rs` (1 test)
- `tests/plugin_remove_tests.rs` (4 tests)

`#[serial]` serializes within a single test binary; cross-binary parallelism still works because each `cargo test --test <name>` runs in its own process. No production code touched.

The `serial_test` crate is already a `[dev-dependencies]` entry as of #253 — no Cargo.toml change.

## How has this been tested?

- `cargo fmt --all --check` ✅
- `cargo clippy --all --all-features --tests -- -D warnings` ✅
- `cargo test` ✅ — full suite passes; serialized tests now run sequentially within their binary, increasing wall-clock time slightly but eliminating the race risk.

## Anything else?

Fourth in the incremental refactor series. PR #5 (error-type hygiene) follows.