### PR TITLE
refactor: fold plugin HTTP logic into WasmEdgeApiClient

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -8,7 +8,8 @@ use std::{
 use crate::{
     constants::{
         CHECKSUM_FILE_NAME, DEFAULT_CONNECT_TIMEOUT_SECS, DEFAULT_REQUEST_TIMEOUT_SECS,
-        DOWNLOAD_BUFFER_SIZE, WASMEDGE_GIT_URL, WASMEDGE_RELEASE_BASE_URL,
+        DOWNLOAD_BUFFER_SIZE, WASMEDGE_GH_RELEASE_TAG_API, WASMEDGE_GIT_URL,
+        WASMEDGE_RELEASE_BASE_URL,
     },
     http::HttpClientConfig,
     prelude::*,
@@ -80,7 +81,7 @@ impl WasmEdgeApiClient {
         let named = NamedTempFile::new_in(tmpdir)?;
         let mut async_file = OpenOptions::new().write(true).open(named.path()).await?;
 
-        download_asset(no_progress, response, &mut async_file).await?;
+        stream_response_to_file(no_progress, response, &mut async_file).await?;
         drop(async_file);
 
         Ok(named)
@@ -172,6 +173,103 @@ impl WasmEdgeApiClient {
         file.rewind()?;
         Ok(())
     }
+
+    /// Download `url` to the file at `to`, streaming chunks and optionally
+    /// showing a progress bar. The target file is created or truncated; its
+    /// parent directory must already exist.
+    ///
+    /// `resource` is the label used in any [`Error::Request`] surfaced from
+    /// this call — pass something descriptive of *what* the caller is
+    /// downloading (e.g. `"plugin download"`) so user-facing errors stay
+    /// specific instead of collapsing every download into a generic label.
+    pub async fn download_to_path(
+        &self,
+        url: Url,
+        to: &Path,
+        no_progress: bool,
+        resource: &'static str,
+    ) -> Result<()> {
+        tracing::debug!(%url, target = %to.display(), %resource, "Starting download to path");
+
+        let client = self.http_client()?;
+        let response = client
+            .get(url)
+            .send()
+            .await
+            .context(RequestSnafu { resource })?
+            .error_for_status()
+            .context(RequestSnafu { resource })?;
+
+        let mut async_file = OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .open(to)
+            .await?;
+        stream_response_to_file(no_progress, response, &mut async_file).await?;
+        Ok(())
+    }
+
+    /// Fetch plugin asset metadata from the GitHub Releases API for `tag`.
+    ///
+    /// A 404 (tag doesn't exist or has no published assets) yields an empty
+    /// Vec rather than an error — callers treat "no assets" and "tag not
+    /// found" the same way. Other non-2xx statuses (403 rate-limit, 5xx
+    /// outage, etc.) and JSON parse failures are surfaced as typed errors.
+    pub async fn github_release_assets(&self, tag: &str) -> Result<Vec<PluginAssetInfo>> {
+        let url = format!("{WASMEDGE_GH_RELEASE_TAG_API}/{tag}");
+        let client = self.http_client()?;
+        let resp = client.get(&url).send().await.context(RequestSnafu {
+            resource: "plugin release metadata",
+        })?;
+        if resp.status() == reqwest::StatusCode::NOT_FOUND {
+            tracing::debug!(tag, "release metadata 404 — tag has no published assets");
+            return Ok(Vec::new());
+        }
+        let resp = resp.error_for_status().context(RequestSnafu {
+            resource: "plugin release metadata",
+        })?;
+        let text = resp.text().await.context(RequestSnafu {
+            resource: "plugin release metadata body",
+        })?;
+        let v: serde_json::Value = serde_json::from_str(&text).context(JsonSnafu {
+            resource: "plugin release metadata",
+        })?;
+        let mut out = Vec::new();
+        if let Some(arr) = v.get("assets").and_then(|a| a.as_array()) {
+            for a in arr {
+                let name = a.get("name").and_then(|s| s.as_str()).unwrap_or("");
+                if !name.starts_with(PLUGIN_ASSET_PREFIX) {
+                    continue;
+                }
+                if let Some((plugin, version, platform)) = parse_plugin_asset_name(name, tag) {
+                    out.push(PluginAssetInfo {
+                        plugin,
+                        version,
+                        platform,
+                    });
+                }
+            }
+        }
+        Ok(out)
+    }
+
+    /// Returns `true` if `url` responds with a successful status to HEAD
+    /// (or GET, as a fallback for servers that disallow HEAD).
+    pub async fn head_ok(&self, url: Url) -> bool {
+        let Ok(client) = self.http_client() else {
+            return false;
+        };
+        if let Ok(resp) = client.head(url.clone()).send().await {
+            if resp.status().is_success() {
+                return true;
+            }
+        }
+        if let Ok(resp) = client.get(url).send().await {
+            return resp.status().is_success();
+        }
+        false
+    }
 }
 
 impl WasmEdgeApiClient {
@@ -200,7 +298,7 @@ impl Default for WasmEdgeApiClient {
 }
 
 #[tracing::instrument(level = tracing::Level::DEBUG, skip(response, target_file), fields(size = response.content_length()))]
-async fn download_asset(
+async fn stream_response_to_file(
     no_progress: bool,
     mut response: Response,
     target_file: &mut File,
@@ -372,6 +470,56 @@ pub fn runtime_ge_015(runtime: &str) -> bool {
         .unwrap_or(true)
 }
 
+/// Metadata describing a single plugin release asset as published on
+/// GitHub's release API.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PluginAssetInfo {
+    pub plugin: String,
+    pub version: String,
+    pub platform: String,
+}
+
+const PLUGIN_ASSET_PREFIX: &str = "WasmEdge-plugin-";
+const PLUGIN_TAR_GZ: &str = ".tar.gz";
+const PLUGIN_ZIP: &str = ".zip";
+
+/// Parse a plugin archive filename like
+/// `WasmEdge-plugin-wasi_nn-ggml-0.15.0-manylinux_2_28_x86_64.tar.gz` into
+/// `(plugin, version, platform)`. The `tag` parameter disambiguates where
+/// the plugin-name portion ends (since plugin names may themselves contain
+/// dashes, e.g. `wasi-logging`).
+fn parse_plugin_asset_name(name: &str, tag: &str) -> Option<(String, String, String)> {
+    let rest = name.strip_prefix(PLUGIN_ASSET_PREFIX)?;
+    let needle = format!("-{tag}-");
+    let idx = rest.find(&needle)?;
+    let plugin = &rest[..idx];
+    let plat_with_ext = &rest[idx + needle.len()..];
+    let platform = plat_with_ext
+        .strip_suffix(PLUGIN_TAR_GZ)
+        .or_else(|| plat_with_ext.strip_suffix(PLUGIN_ZIP))
+        .unwrap_or(plat_with_ext);
+    Some((plugin.to_string(), tag.to_string(), platform.to_string()))
+}
+
+/// Build the download URL for a plugin archive on GitHub releases.
+///
+/// Produces `{base}/{runtime}/WasmEdge-plugin-{plugin}-{runtime}-{platform}.{ext}`
+/// where `ext` is `.zip` when `is_zip` is `true`, else `.tar.gz`. Callers
+/// pick the extension themselves: the runtime installer maps it from the
+/// host OS (Windows → zip, others → tar.gz), but the `plugin list --all`
+/// probe builds *both* variants per host to discover whichever exists on
+/// the release.
+pub fn plugin_asset_url(plugin: &str, runtime: &str, platform: &str, is_zip: bool) -> Result<Url> {
+    let ext = if is_zip { "zip" } else { "tar.gz" };
+    let filename = format!("{PLUGIN_ASSET_PREFIX}{plugin}-{runtime}-{platform}.{ext}");
+    let mut url = Url::parse(WASMEDGE_RELEASE_BASE_URL)
+        .expect("WASMEDGE_RELEASE_BASE_URL must be a valid URL");
+    url.path_segments_mut()
+        .expect("base is valid URL")
+        .extend(&[runtime, &filename]);
+    Ok(url)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -506,5 +654,93 @@ mod tests {
         assert!(runtime_ge_015("1.0.0"));
         // Unparseable input fails open (defensive).
         assert!(runtime_ge_015("not-a-version"));
+    }
+
+    #[test]
+    fn parse_plugin_asset_name_targz() {
+        let parsed = parse_plugin_asset_name(
+            "WasmEdge-plugin-wasi_nn-ggml-0.15.0-manylinux_2_28_x86_64.tar.gz",
+            "0.15.0",
+        );
+        assert_eq!(
+            parsed,
+            Some((
+                "wasi_nn-ggml".to_string(),
+                "0.15.0".to_string(),
+                "manylinux_2_28_x86_64".to_string(),
+            ))
+        );
+    }
+
+    #[test]
+    fn parse_plugin_asset_name_zip() {
+        let parsed = parse_plugin_asset_name(
+            "WasmEdge-plugin-wasi_crypto-0.14.1-windows_x86_64.zip",
+            "0.14.1",
+        );
+        assert_eq!(
+            parsed,
+            Some((
+                "wasi_crypto".to_string(),
+                "0.14.1".to_string(),
+                "windows_x86_64".to_string(),
+            ))
+        );
+    }
+
+    #[test]
+    fn parse_plugin_asset_name_rejects_unrelated_prefix() {
+        assert_eq!(
+            parse_plugin_asset_name("WasmEdge-0.15.0-linux.tar.gz", "0.15.0"),
+            None
+        );
+    }
+
+    #[test]
+    fn parse_plugin_asset_name_rejects_tag_mismatch() {
+        // The needle "-0.15.0-" is not present in an archive tagged 0.14.1.
+        assert_eq!(
+            parse_plugin_asset_name(
+                "WasmEdge-plugin-wasi_nn-ggml-0.14.1-manylinux2014_x86_64.tar.gz",
+                "0.15.0"
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn parse_plugin_asset_name_handles_dashed_plugin_names() {
+        let parsed = parse_plugin_asset_name(
+            "WasmEdge-plugin-wasi-logging-0.15.0-darwin_arm64.tar.gz",
+            "0.15.0",
+        );
+        assert_eq!(
+            parsed,
+            Some((
+                "wasi-logging".to_string(),
+                "0.15.0".to_string(),
+                "darwin_arm64".to_string(),
+            ))
+        );
+    }
+
+    #[test]
+    fn plugin_asset_url_targz() {
+        let url = plugin_asset_url("wasi_nn-ggml", "0.15.0", "manylinux_2_28_x86_64", false)
+            .expect("url builds");
+        assert_eq!(
+            url.as_str(),
+            "https://github.com/WasmEdge/WasmEdge/releases/download/0.15.0/WasmEdge-plugin-wasi_nn-ggml-0.15.0-manylinux_2_28_x86_64.tar.gz"
+        );
+    }
+
+    #[test]
+    fn plugin_asset_url_zip() {
+        let url =
+            plugin_asset_url("wasi_crypto", "0.14.1", "windows_x86_64", true).expect("url builds");
+        assert_eq!(
+            url.as_str(),
+            "https://github.com/WasmEdge/WasmEdge/releases/download/0.14.1/WasmEdge-plugin-wasi_crypto-0.14.1-windows_x86_64.zip"
+        );
     }
 }

--- a/src/commands/plugin/install.rs
+++ b/src/commands/plugin/install.rs
@@ -4,15 +4,13 @@ use clap::{value_parser, Args};
 use tokio::fs;
 use walkdir::WalkDir;
 
-use crate::constants::WASMEDGE_RELEASE_BASE_URL;
+use crate::api::plugin_asset_url;
 use crate::system::plugins::plugin_platform_key;
 use crate::{
     cli::{CommandContext, CommandExecutor},
     commands::default_path,
     error::{Error, Result},
-    fs as wfs,
-    http::HttpClientConfig,
-    system,
+    fs as wfs, system,
 };
 
 use super::utils::find_plugin_shared_objects;
@@ -108,15 +106,7 @@ impl CommandExecutor for PluginInstallArgs {
             };
 
             let is_windows = matches!(specs.os.os_type, crate::target::TargetOS::Windows);
-            let ext = if is_windows { "zip" } else { "tar.gz" };
-            let url = format!(
-                "{base}/{ver}/WasmEdge-plugin-{name}-{ver}-{os_key}.{ext}",
-                base = WASMEDGE_RELEASE_BASE_URL,
-                name = name,
-                ver = pver,
-                os_key = os_key,
-                ext = ext,
-            );
+            let url = plugin_asset_url(name, &pver, &os_key, is_windows)?;
             tracing::debug!(%name, %pver, %url, "Downloading plugin");
 
             let workspace = tmp_root.join(format!("{name}-{pver}"));
@@ -127,7 +117,9 @@ impl CommandExecutor for PluginInstallArgs {
                 workspace.join("plugin.tar.gz")
             };
 
-            download_with_progress(&ctx, &url, &archive_path).await?;
+            ctx.client
+                .download_to_path(url, &archive_path, ctx.no_progress, "plugin download")
+                .await?;
 
             let mut file = std::fs::OpenOptions::new()
                 .read(true)
@@ -200,41 +192,4 @@ pub(super) fn select_runtime_version(
             version: "<none installed>".to_string(),
         }),
     }
-}
-
-async fn download_with_progress(ctx: &CommandContext, url: &str, to: &Path) -> Result<()> {
-    use tokio::io::AsyncWriteExt as _;
-
-    let client = HttpClientConfig::new()
-        .with_connect_timeout(ctx.client.connect_timeout)
-        .with_request_timeout(ctx.client.request_timeout)
-        .build()?;
-
-    let resp = client
-        .get(url)
-        .send()
-        .await
-        .map_err(|source| Error::Request {
-            source,
-            resource: "plugin download",
-        })?;
-
-    let resp = resp.error_for_status().map_err(|source| Error::Request {
-        source,
-        resource: "plugin download",
-    })?;
-
-    let bytes = resp.bytes().await.map_err(|source| Error::Request {
-        source,
-        resource: "plugin download body",
-    })?;
-
-    let mut file = tokio::fs::OpenOptions::new()
-        .create(true)
-        .write(true)
-        .truncate(true)
-        .open(to)
-        .await?;
-    file.write_all(&bytes).await?;
-    Ok(())
 }

--- a/src/commands/plugin/list.rs
+++ b/src/commands/plugin/list.rs
@@ -1,18 +1,11 @@
-use crate::api::runtime_ge_015;
+use crate::api::{plugin_asset_url, runtime_ge_015};
 use crate::cli::{CommandContext, CommandExecutor};
-use crate::constants::{WASMEDGE_GH_RELEASE_TAG_API, WASMEDGE_RELEASE_BASE_URL};
 use crate::prelude::*;
 use crate::system;
 use crate::system::plugins::plugin_platform_key;
 use clap::Args;
-use serde_json::Value;
 use std::cmp::Ordering;
 use std::collections::HashSet;
-
-const UA: &str = "wasmedgeup";
-const ASSET_PREFIX: &str = "WasmEdge-plugin-";
-const TAR_GZ: &str = ".tar.gz";
-const ZIP: &str = ".zip";
 
 const UBUNTU20_PREFIX: &str = "ubuntu20_04_";
 const UBUNTU22_PREFIX: &str = "ubuntu22_04_";
@@ -35,7 +28,7 @@ pub struct PluginListArgs {
 }
 
 impl CommandExecutor for PluginListArgs {
-    async fn execute(self, _ctx: CommandContext) -> Result<()> {
+    async fn execute(self, ctx: CommandContext) -> Result<()> {
         let spec = system::detect();
 
         // Short-circuit on `--runtime`: when the user passes one explicitly we
@@ -77,7 +70,7 @@ impl CommandExecutor for PluginListArgs {
                 .features
                 .contains(&crate::system::spec::CpuFeature::AVX);
 
-        let assets = match fetch_release_assets(&runtime).await {
+        let assets = match ctx.client.github_release_assets(&runtime).await {
             Ok(v) => v,
             Err(e) => {
                 tracing::warn!(error = %e, tag = %runtime, "failed to fetch plugin release assets");
@@ -138,13 +131,10 @@ impl CommandExecutor for PluginListArgs {
                 };
                 for probe in probes {
                     for plat in &platform_candidates {
-                        let url_targz = format!(
-                            "{WASMEDGE_RELEASE_BASE_URL}/{runtime}/{ASSET_PREFIX}{probe}-{runtime}-{plat}{TAR_GZ}"
-                        );
-                        let url_zip = format!(
-                            "{WASMEDGE_RELEASE_BASE_URL}/{runtime}/{ASSET_PREFIX}{probe}-{runtime}-{plat}{ZIP}"
-                        );
-                        let available = head_ok(&url_targz).await || head_ok(&url_zip).await;
+                        let url_targz = plugin_asset_url(probe, &runtime, plat, false)?;
+                        let url_zip = plugin_asset_url(probe, &runtime, plat, true)?;
+                        let available = ctx.client.head_ok(url_targz).await
+                            || ctx.client.head_ok(url_zip).await;
                         rows.push(Row {
                             name: probe.to_string(),
                             version: runtime.clone(),
@@ -236,90 +226,6 @@ fn order_plugins(a: &str, b: &str, cuda: bool, noavx: bool) -> Ordering {
     rank(a).cmp(&rank(b)).then(a.cmp(b))
 }
 
-async fn head_ok(url: &str) -> bool {
-    let client = reqwest::Client::new();
-    if let Ok(resp) = client.head(url).send().await {
-        if resp.status().is_success() {
-            return true;
-        }
-    }
-    if let Ok(resp) = client.get(url).send().await {
-        return resp.status().is_success();
-    }
-    false
-}
-
-#[derive(Debug, Clone)]
-struct AssetInfo {
-    plugin: String,
-    version: String,
-    platform: String,
-}
-
-async fn fetch_release_assets(tag: &str) -> Result<Vec<AssetInfo>> {
-    use snafu::ResultExt;
-
-    let url = format!("{WASMEDGE_GH_RELEASE_TAG_API}/{tag}");
-    let client = reqwest::Client::new();
-    let resp = client
-        .get(&url)
-        .header("User-Agent", UA)
-        .send()
-        .await
-        .context(RequestSnafu {
-            resource: "plugin release metadata",
-        })?;
-    // A 404 means the tag doesn't exist (or has no published assets) —
-    // degrade gracefully to an empty list. Other non-2xx statuses (403
-    // rate-limit, 5xx outage, etc.) propagate as errors so the caller can
-    // surface them to the user instead of silently reporting "no plugins".
-    if resp.status() == reqwest::StatusCode::NOT_FOUND {
-        tracing::debug!(tag, "release metadata 404 — tag has no published assets");
-        return Ok(Vec::new());
-    }
-    let resp = resp.error_for_status().context(RequestSnafu {
-        resource: "plugin release metadata",
-    })?;
-    let text = resp.text().await.context(RequestSnafu {
-        resource: "plugin release metadata body",
-    })?;
-    let v: Value = serde_json::from_str(&text).context(JsonSnafu {
-        resource: "plugin release metadata",
-    })?;
-    let mut out = Vec::new();
-    if let Some(arr) = v.get("assets").and_then(|a| a.as_array()) {
-        for a in arr {
-            let name = a.get("name").and_then(|s| s.as_str()).unwrap_or("");
-            if !name.starts_with(ASSET_PREFIX) {
-                continue;
-            }
-            if let Some(info) = parse_asset_name(name, tag) {
-                out.push(AssetInfo {
-                    plugin: info.0,
-                    version: info.1,
-                    platform: info.2,
-                });
-            }
-        }
-    }
-    Ok(out)
-}
-
-fn parse_asset_name(name: &str, tag: &str) -> Option<(String, String, String)> {
-    let rest = name.strip_prefix(ASSET_PREFIX)?;
-    let needle = format!("-{tag}-");
-    if let Some(idx) = rest.find(&needle) {
-        let plugin = &rest[..idx];
-        let plat_with_ext = &rest[idx + needle.len()..];
-        let platform = plat_with_ext
-            .strip_suffix(TAR_GZ)
-            .or_else(|| plat_with_ext.strip_suffix(ZIP))
-            .unwrap_or(plat_with_ext);
-        return Some((plugin.to_string(), tag.to_string(), platform.to_string()));
-    }
-    None
-}
-
 pub fn platform_fallbacks(primary: &str, runtime: &str) -> Vec<String> {
     let rt_ge_015 = runtime_ge_015(runtime);
     let mut out = vec![primary.to_string()];
@@ -337,73 +243,4 @@ pub fn platform_fallbacks(primary: &str, runtime: &str) -> Vec<String> {
     out.sort();
     out.dedup();
     out
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn parse_asset_name_targz() {
-        let parsed = parse_asset_name(
-            "WasmEdge-plugin-wasi_nn-ggml-0.15.0-manylinux_2_28_x86_64.tar.gz",
-            "0.15.0",
-        );
-        assert_eq!(
-            parsed,
-            Some((
-                "wasi_nn-ggml".to_string(),
-                "0.15.0".to_string(),
-                "manylinux_2_28_x86_64".to_string(),
-            ))
-        );
-    }
-
-    #[test]
-    fn parse_asset_name_zip() {
-        let parsed = parse_asset_name(
-            "WasmEdge-plugin-wasi_crypto-0.14.1-windows_x86_64.zip",
-            "0.14.1",
-        );
-        assert_eq!(
-            parsed,
-            Some((
-                "wasi_crypto".to_string(),
-                "0.14.1".to_string(),
-                "windows_x86_64".to_string(),
-            ))
-        );
-    }
-
-    #[test]
-    fn parse_asset_name_rejects_unrelated_prefix() {
-        let parsed = parse_asset_name("WasmEdge-0.15.0-linux.tar.gz", "0.15.0");
-        assert_eq!(parsed, None);
-    }
-
-    #[test]
-    fn parse_asset_name_rejects_tag_mismatch() {
-        // The needle "-0.15.0-" is not present in an archive tagged 0.14.1.
-        let parsed = parse_asset_name(
-            "WasmEdge-plugin-wasi_nn-ggml-0.14.1-manylinux2014_x86_64.tar.gz",
-            "0.15.0",
-        );
-        assert_eq!(parsed, None);
-    }
-
-    #[test]
-    fn parse_asset_name_plugin_name_may_contain_dashes() {
-        let parsed = parse_asset_name(
-            "WasmEdge-plugin-wasi-logging-0.15.0-darwin_arm64.tar.gz",
-            "0.15.0",
-        );
-        assert_eq!(
-            parsed,
-            Some((
-                "wasi-logging".to_string(),
-                "0.15.0".to_string(),
-                "darwin_arm64".to_string(),
-            ))
-        );
-    }
 }


### PR DESCRIPTION
## Which GitHub issue does this PR close?

N/A — follow-up to #264. Part of an incremental refactor series.

## Why is this needed?

The plugin subsystem maintained its own `reqwest::Client` construction sites and asset-URL format strings, duplicating what `WasmEdgeApiClient` already did for runtime installs:

- `src/commands/plugin/install.rs::download_with_progress` built a fresh `reqwest::Client` from `HttpClientConfig`, ignoring `ctx.client.connect_timeout` / `ctx.client.request_timeout` overrides users may have set via `--connect-timeout` / `--request-timeout`.
- `src/commands/plugin/list.rs::fetch_release_assets` and `head_ok` did the same — every call rebuilt a default `reqwest::Client` and missed the configured User-Agent string.
- The plugin archive URL was assembled from a per-file `format!()` template in three places, with one variant in `plugin/install.rs`, another in `plugin/list.rs::head_ok` probes, and constants scattered across both.

Consolidating behind `WasmEdgeApiClient` means every HTTP call respects the CLI's timeout flags and User-Agent, and the plugin URL template lives in exactly one place.

## What does this PR change?

### `src/api/mod.rs`
- Renames the free streaming helper `download_asset` → `stream_response_to_file` to disambiguate it from `WasmEdgeApiClient::download_asset`.
- Adds `WasmEdgeApiClient::download_to_path(url, to, no_progress)` — reuses the streaming helper, creates/truncates the target file, supports the progress bar.
- Adds `WasmEdgeApiClient::github_release_assets(tag)` — moves the GitHub Releases API call out of `plugin/list.rs` into the API client. A 404 (tag doesn't exist) yields `Ok(Vec::new())`; other non-2xx (403, 5xx, etc.) propagate via `error_for_status` so callers see the actual status. The same 404-vs-other-non-2xx contract that landed in #264 for the now-deleted `fetch_release_assets`.
- Adds `WasmEdgeApiClient::head_ok(url)` — replaces the free `head_ok` in `plugin/list.rs`.
- Adds free `plugin_asset_url(plugin, runtime, platform, zip)` so both `plugin/install.rs` and `plugin/list.rs` construct plugin archive URLs through one helper.
- Adds public `PluginAssetInfo` struct and private `parse_plugin_asset_name` (relocated from `plugin/list.rs`).
- Moves the `parse_asset_name` and asset-URL unit tests here.

### `src/commands/plugin/install.rs`
- Deletes `download_with_progress` (34 lines); replaces with `ctx.client.download_to_path`.
- Drops the `HttpClientConfig` import and the local `GH_RELEASE_DOWNLOAD_BASE` constant.
- Constructs the asset URL via `plugin_asset_url`.

### `src/commands/plugin/list.rs`
- Deletes `fetch_release_assets`, `head_ok`, `parse_asset_name`, the `AssetInfo` struct, and the `UA` / `ASSET_PREFIX` / `TAR_GZ` / `ZIP` constants.
- Calls `ctx.client.github_release_assets` and `ctx.client.head_ok`.
- Constructs asset URLs via `plugin_asset_url` instead of `format!`.

### Net effect

Plugin commands no longer allocate their own `reqwest::Client`. The lib-test bin grows from 29 to 31 tests because the parse/url builders moved to `api::tests`.

## How has this been tested?

- `cargo fmt --all --check` ✅
- `cargo clippy --all --all-features --tests -- -D warnings` ✅
- `cargo test` ✅ — full suite passes (73 tests).

## Anything else?

Sixth in the incremental refactor series. The `use latest` semantic fix follows in PR #7.