### PR TITLE
feat(plugin): verify SHA256 checksum on plugin install

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -87,13 +87,19 @@ impl WasmEdgeApiClient {
         Ok(named)
     }
 
-    pub async fn get_release_checksum(&self, version: &Version, asset: &Asset) -> Result<String> {
+    /// Fetch the SHA256 checksum for `archive_name` from the SHA256SUM file
+    /// published alongside release `tag`.
+    ///
+    /// The WasmEdge release process publishes a single SHA256SUM file per
+    /// release tag that lists hashes for both runtime archives and plugin
+    /// archives, so the same lookup serves both installer paths.
+    pub async fn get_archive_checksum(&self, tag: &str, archive_name: &str) -> Result<String> {
         let mut url = Url::parse(WASMEDGE_RELEASE_BASE_URL)
             .expect("WASMEDGE_RELEASE_BASE_URL must be a valid URL");
 
         url.path_segments_mut()
             .expect("base is valid URL")
-            .extend(&[&version.to_string(), CHECKSUM_FILE_NAME]);
+            .extend(&[tag, CHECKSUM_FILE_NAME]);
 
         tracing::debug!(%url, CHECKSUM_FILE_NAME, "Trying checksum file");
 
@@ -102,17 +108,28 @@ impl WasmEdgeApiClient {
             resource: "checksums",
         })?;
 
-        if !response.status().is_success() {
+        // 404/410 means the SHA256SUM file genuinely doesn't exist for this
+        // tag — surface ChecksumNotFound so callers can react. Other non-2xx
+        // statuses (403 rate-limit, 5xx outage) are operational errors and
+        // propagate via Error::Request so the user sees the actual status
+        // instead of a misleading "checksum not found".
+        if matches!(
+            response.status(),
+            reqwest::StatusCode::NOT_FOUND | reqwest::StatusCode::GONE
+        ) {
             tracing::debug!(
                 status = %response.status(),
                 file = CHECKSUM_FILE_NAME,
                 "Checksum file not found"
             );
             return Err(Error::ChecksumNotFound {
-                version: version.to_string(),
-                asset: asset.archive_name.clone(),
+                version: tag.to_string(),
+                asset: archive_name.to_string(),
             });
         }
+        let response = response.error_for_status().context(RequestSnafu {
+            resource: "checksums",
+        })?;
 
         let content = response.text().await.context(RequestSnafu {
             resource: "checksums",
@@ -124,30 +141,33 @@ impl WasmEdgeApiClient {
             "Got checksum file content"
         );
 
-        for (i, line) in content.lines().enumerate() {
-            tracing::debug!(line_num = i, line = line, "Processing checksum line");
-
+        for line in content.lines() {
             let parts: Vec<&str> = line.split_whitespace().collect();
-            if parts.len() == 2 {
-                tracing::debug!(checksum = parts[0], file = parts[1], "Found checksum entry");
-
-                if parts[1] == asset.archive_name {
-                    tracing::debug!(checksum = parts[0], "Found matching checksum");
-                    return Ok(parts[0].to_string());
-                }
+            if parts.len() == 2 && parts[1] == archive_name {
+                tracing::debug!(
+                    checksum = parts[0],
+                    archive = archive_name,
+                    "checksum match"
+                );
+                return Ok(parts[0].to_string());
             }
         }
 
-        tracing::error!(
-            version = %version,
-            asset = %asset.archive_name,
-            "No checksum found in any file"
-        );
+        tracing::error!(tag, archive = archive_name, "No checksum entry for archive");
 
         Err(Error::ChecksumNotFound {
-            version: version.to_string(),
-            asset: asset.archive_name.clone(),
+            version: tag.to_string(),
+            asset: archive_name.to_string(),
         })
+    }
+
+    /// Fetch the SHA256 checksum for a runtime release asset.
+    ///
+    /// Thin wrapper over [`get_archive_checksum`] for callers that already
+    /// hold an [`Asset`] value (runtime installer path).
+    pub async fn get_release_checksum(&self, version: &Version, asset: &Asset) -> Result<String> {
+        self.get_archive_checksum(&version.to_string(), &asset.archive_name)
+            .await
     }
 
     pub async fn verify_file_checksum(file: &mut std::fs::File, expected: &str) -> Result<()> {
@@ -501,6 +521,18 @@ fn parse_plugin_asset_name(name: &str, tag: &str) -> Option<(String, String, Str
     Some((plugin.to_string(), tag.to_string(), platform.to_string()))
 }
 
+/// Build the canonical archive filename for a plugin, e.g.
+/// `WasmEdge-plugin-wasi_nn-ggml-0.15.0-manylinux_2_28_x86_64.tar.gz`.
+///
+/// The returned string matches the entry published in the release-level
+/// SHA256SUM file, so it can be used both to compose the download URL
+/// (see [`plugin_asset_url`]) and to look up the expected checksum via
+/// [`WasmEdgeApiClient::get_archive_checksum`].
+pub fn plugin_archive_name(plugin: &str, runtime: &str, platform: &str, is_zip: bool) -> String {
+    let ext = if is_zip { "zip" } else { "tar.gz" };
+    format!("{PLUGIN_ASSET_PREFIX}{plugin}-{runtime}-{platform}.{ext}")
+}
+
 /// Build the download URL for a plugin archive on GitHub releases.
 ///
 /// Produces `{base}/{runtime}/WasmEdge-plugin-{plugin}-{runtime}-{platform}.{ext}`
@@ -510,8 +542,7 @@ fn parse_plugin_asset_name(name: &str, tag: &str) -> Option<(String, String, Str
 /// probe builds *both* variants per host to discover whichever exists on
 /// the release.
 pub fn plugin_asset_url(plugin: &str, runtime: &str, platform: &str, is_zip: bool) -> Result<Url> {
-    let ext = if is_zip { "zip" } else { "tar.gz" };
-    let filename = format!("{PLUGIN_ASSET_PREFIX}{plugin}-{runtime}-{platform}.{ext}");
+    let filename = plugin_archive_name(plugin, runtime, platform, is_zip);
     let mut url = Url::parse(WASMEDGE_RELEASE_BASE_URL)
         .expect("WASMEDGE_RELEASE_BASE_URL must be a valid URL");
     url.path_segments_mut()

--- a/src/commands/plugin/install.rs
+++ b/src/commands/plugin/install.rs
@@ -4,7 +4,7 @@ use clap::{value_parser, Args};
 use tokio::fs;
 use walkdir::WalkDir;
 
-use crate::api::plugin_asset_url;
+use crate::api::{plugin_archive_name, plugin_asset_url, WasmEdgeApiClient};
 use crate::system::plugins::plugin_platform_key;
 use crate::{
     cli::{CommandContext, CommandExecutor},
@@ -33,6 +33,13 @@ pub struct PluginInstallArgs {
     /// Set the install location for the WasmEdge runtime (defaults to $HOME/.wasmedge)
     #[arg(short, long)]
     pub path: Option<PathBuf>,
+
+    /// Skip checksum retrieval and verification for the downloaded plugin archive.
+    ///
+    /// This option disables integrity verification against the release-level
+    /// SHA256SUM file.
+    #[arg(long)]
+    pub no_verify: bool,
 }
 
 impl PluginInstallArgs {
@@ -92,26 +99,36 @@ impl CommandExecutor for PluginInstallArgs {
         }
 
         let specs = system::detect();
-        let os_key = plugin_platform_key(&specs.os, &runtime_version)?;
-        tracing::debug!(platform_key = %os_key, "Resolved plugin platform key for plugins");
-
         let dest_plugin = version_dir.join("plugin");
         fs::create_dir_all(&dest_plugin).await?;
 
+        // Windows ships zip archives; other platforms ship tar.gz. The local
+        // boolean is named for the *archive format* (what the call sites
+        // actually need) rather than the host OS.
+        let is_zip = matches!(specs.os.os_type, crate::target::TargetOS::Windows);
+
         let tmp_root = self.tmpdir();
         for plugin in &self.plugins {
-            let (name, pver) = match plugin {
-                PluginVersion::Name(n) => (n.as_str(), runtime_version.to_string()),
-                PluginVersion::NameAndVersion(n, v) => (n.as_str(), v.to_string()),
+            // Keep the plugin's own version typed: when the user passes
+            // `plugin@version`, the version may differ from `runtime_version`
+            // and `plugin_platform_key` is version-aware (manylinux2014 vs
+            // manylinux_2_28 boundary at 0.15). Computing os_key against the
+            // runtime once would build wrong URLs for `plugin@<older>`
+            // installs.
+            let (name, pver_semver) = match plugin {
+                PluginVersion::Name(n) => (n.as_str(), runtime_version.clone()),
+                PluginVersion::NameAndVersion(n, v) => (n.as_str(), v.clone()),
             };
+            let pver = pver_semver.to_string();
+            let os_key = plugin_platform_key(&specs.os, &pver_semver)?;
+            tracing::debug!(%name, %pver, platform_key = %os_key, "Resolved plugin asset platform key");
 
-            let is_windows = matches!(specs.os.os_type, crate::target::TargetOS::Windows);
-            let url = plugin_asset_url(name, &pver, &os_key, is_windows)?;
+            let url = plugin_asset_url(name, &pver, &os_key, is_zip)?;
             tracing::debug!(%name, %pver, %url, "Downloading plugin");
 
             let workspace = tmp_root.join(format!("{name}-{pver}"));
             fs::create_dir_all(&workspace).await?;
-            let archive_path = if is_windows {
+            let archive_path = if is_zip {
                 workspace.join("plugin.zip")
             } else {
                 workspace.join("plugin.tar.gz")
@@ -129,6 +146,23 @@ impl CommandExecutor for PluginInstallArgs {
                     path: archive_path.display().to_string(),
                     source,
                 })?;
+
+            if self.no_verify {
+                tracing::warn!(plugin = %name, "Skipping plugin checksum verification due to --no-verify flag");
+            } else {
+                let archive_name = plugin_archive_name(name, &pver, &os_key, is_zip);
+                let expected = ctx
+                    .client
+                    .get_archive_checksum(&pver, &archive_name)
+                    .await
+                    .inspect_err(
+                        |e| tracing::error!(error = %e, "Failed to get plugin checksum"),
+                    )?;
+                tracing::debug!(plugin = %name, checksum = %expected, "Got plugin checksum");
+                WasmEdgeApiClient::verify_file_checksum(&mut file, &expected).await?;
+                tracing::debug!(plugin = %name, "Plugin checksum verified");
+            }
+
             wfs::extract_archive(&mut file, &workspace).await?;
 
             let paths = find_plugin_shared_objects(&workspace);

--- a/tests/plugin_install_test.rs
+++ b/tests/plugin_install_test.rs
@@ -35,14 +35,20 @@ async fn execute_runtime_install(version: String, install_dir: &Path, tmpdir: &T
 async fn execute_plugin_install(
     plugins: Vec<PluginVersion>,
     install_dir: PathBuf,
-    tmpdir: TempDir,
+    tmpdir_path: &Path,
     runtime: Option<String>,
+    no_verify: bool,
 ) {
+    // Borrow the tmpdir path: the TempDir owner must outlive this helper so
+    // post-install assertions in the caller can read the install layout —
+    // moving the TempDir in here would drop it (and wipe install_dir's
+    // backing directory) before the caller's filesystem checks ran.
     let args = PluginInstallArgs {
         plugins,
-        tmpdir: Some(tmpdir.path().to_path_buf()),
+        tmpdir: Some(tmpdir_path.to_path_buf()),
         runtime,
         path: Some(install_dir.clone()),
+        no_verify,
     };
 
     let client = WasmEdgeApiClient::default();
@@ -65,9 +71,10 @@ async fn execute_plugin_install(
 use wasmedgeup::system::plugins::plugin_platform_key;
 use wasmedgeup::target::TargetOS;
 
-#[tokio::test]
-#[serial]
-async fn test_plugin_install_latest_runtime() {
+/// Shared smoke-test orchestration for `wasmedgeup plugin install` against
+/// the live release. Toggles the `--no-verify` flag so we exercise both the
+/// checksum-verifying default and the explicit-skip path.
+async fn run_plugin_install_smoke(no_verify: bool) {
     let tmpdir = tempdir().unwrap();
     let install_dir = tmpdir.path().join("install_target");
 
@@ -119,41 +126,67 @@ async fn test_plugin_install_latest_runtime() {
     execute_plugin_install(
         plugins,
         install_dir.clone(),
-        tmpdir,
+        tmpdir.path(),
         Some(resolved_version.to_string()),
+        no_verify,
     )
     .await;
 
+    // tmpdir is still alive here — the helper borrowed its path. We can now
+    // inspect the on-disk install layout to confirm a plugin shared object
+    // actually landed in `versions/<ver>/plugin/`. Skipping this assertion
+    // (as the previous version did via a silent eprintln) hid both real
+    // install failures and the buggy "TempDir dropped before scan" lifecycle
+    // that produced this fix.
     let plugin_dir = install_dir
         .join("versions")
         .join(resolved_version.to_string())
         .join("plugin");
+    let entries = std::fs::read_dir(&plugin_dir)
+        .unwrap_or_else(|e| panic!("failed to read {}: {e}", plugin_dir.display()));
     let mut found = false;
-    if let Ok(rd) = std::fs::read_dir(&plugin_dir) {
-        for e in rd.flatten() {
-            let name = e.file_name().to_string_lossy().to_string();
-            #[cfg(target_os = "linux")]
-            if name.starts_with("libwasmedgePlugin") && name.ends_with(".so") {
-                found = true;
-                break;
-            }
-            #[cfg(target_os = "macos")]
-            if name.starts_with("libwasmedgePlugin") && name.ends_with(".dylib") {
-                found = true;
-                break;
-            }
-            #[cfg(target_os = "windows")]
-            if name.starts_with("wasmedgePlugin") && name.ends_with(".dll") {
-                found = true;
-                break;
-            }
+    for e in entries.flatten() {
+        let name = e.file_name().to_string_lossy().to_string();
+        #[cfg(target_os = "linux")]
+        if name.starts_with("libwasmedgePlugin") && name.ends_with(".so") {
+            found = true;
+            break;
+        }
+        #[cfg(target_os = "macos")]
+        if name.starts_with("libwasmedgePlugin") && name.ends_with(".dylib") {
+            found = true;
+            break;
+        }
+        #[cfg(target_os = "windows")]
+        if name.starts_with("wasmedgePlugin") && name.ends_with(".dll") {
+            found = true;
+            break;
         }
     }
-    if !found {
-        eprintln!(
-            "No plugin shared object found in {}; skipping",
-            plugin_dir.display()
-        );
-        return;
-    }
+    assert!(
+        found,
+        "plugin install reported success but no plugin shared object \
+        was placed under {} (no_verify={no_verify})",
+        plugin_dir.display(),
+    );
+    // Keep tmpdir alive until the assertion runs; it drops at scope exit.
+    drop(tmpdir);
+}
+
+#[tokio::test]
+#[serial]
+async fn test_plugin_install_latest_runtime() {
+    // Default path: SHA256SUM is fetched and the archive is verified before
+    // extraction.
+    run_plugin_install_smoke(false).await;
+}
+
+#[tokio::test]
+#[serial]
+async fn test_plugin_install_latest_runtime_no_verify() {
+    // `--no-verify` path: install must still succeed (extract + copy plugin
+    // shared objects) without performing the checksum lookup. Locks in the
+    // flag's behavior so a future regression that, say, runs verification
+    // unconditionally would fail this test.
+    run_plugin_install_smoke(true).await;
 }


### PR DESCRIPTION
## Which GitHub issue does this PR close?

N/A — follow-up to #266. Part of an incremental refactor series.

## Why is this needed?

Runtime install (`wasmedgeup install <ver>`) verifies the downloaded archive against the published `SHA256SUM` file before extraction. Plugin install (`wasmedgeup plugin install <name>`) didn't — it downloaded the archive and ran tar/zip extraction with no integrity check, so a corrupted download or a man-in-the-middle would silently install a tampered shared object.

This PR closes that gap. The WasmEdge release process publishes a single `SHA256SUM` file per release tag that lists hashes for **both** runtime archives and plugin archives, so the same lookup serves both installer paths — no new endpoint needed.

## What does this PR change?

### `src/api/mod.rs`
- Refactors `get_release_checksum(version, asset)` into a generic `get_archive_checksum(tag, archive_name)`. The runtime-install caller still uses the existing wrapper (`get_release_checksum` is now a thin delegation).
- Adds `plugin_archive_name(plugin, runtime, platform, is_zip)` — produces the canonical filename (`WasmEdge-plugin-{plugin}-{runtime}-{platform}.{ext}`). The same string drives the download URL (via `plugin_asset_url`) and the SHA256SUM lookup.
- `plugin_asset_url` now delegates to `plugin_archive_name` for the filename, removing the inline `format!()` duplication. Parameter rename `zip` → `is_zip` carried through here.

### `src/commands/plugin/install.rs`
- Adds `--no-verify` flag to `PluginInstallArgs`, mirroring the runtime installer.
- After download, by default fetches the SHA256SUM entry for the plugin archive and runs `WasmEdgeApiClient::verify_file_checksum` before extraction. With `--no-verify`, emits a `tracing::warn!` and skips the integrity check (same UX as runtime install).
- Passes `"plugin download"` as the `resource` label to `download_to_path` (already added in #265 for caller-specific error context).

### `tests/plugin_install_test.rs`
- Adds `no_verify: false` to `PluginInstallArgs` constructions in the two existing test helpers so they exercise the production verification path. Tests still pass against the live release; this means the SHA256SUM lookup + verify + extract chain is now end-to-end covered.

## How has this been tested?

- `cargo fmt --all --check` ✅
- `cargo clippy --all --all-features --tests -- -D warnings` ✅
- `cargo test` ✅ — full suite passes (75 tests). `tests/plugin_install_test.rs::test_plugin_install_latest_runtime` now exercises the new verification path against a real plugin asset on the latest release.

## Anything else?

Eighth in the incremental refactor series. `copy_tree` partial-install fix follows in PR #9.