### PR TITLE
refactor: run blocking archive extraction and git2 calls on spawn_blocking

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -46,19 +46,29 @@ impl WasmEdgeApiClient {
             .build()
     }
 
-    pub fn releases(&self, filter: ReleasesFilter, num_releases: usize) -> Result<Vec<Version>> {
-        let releases = releases::get_all(WASMEDGE_GIT_URL, filter)?;
+    /// Fetch the first `num_releases` WasmEdge versions from the upstream git
+    /// remote. The underlying `git2::Remote::connect` call is blocking; we run
+    /// it on `spawn_blocking` so the tokio worker stays free.
+    pub async fn releases(
+        &self,
+        filter: ReleasesFilter,
+        num_releases: usize,
+    ) -> Result<Vec<Version>> {
+        let releases = fetch_releases_blocking(filter).await?;
         Ok(releases.into_iter().take(num_releases).collect())
     }
 
-    pub fn latest_release(&self) -> Result<Version> {
-        let releases = releases::get_all(WASMEDGE_GIT_URL, ReleasesFilter::Stable)?;
+    /// Fetch the newest stable WasmEdge release via a `spawn_blocking` wrapper
+    /// around the blocking git2 remote call.
+    pub async fn latest_release(&self) -> Result<Version> {
+        let releases = fetch_releases_blocking(ReleasesFilter::Stable).await?;
         releases.into_iter().next().ok_or(Error::NoReleasesFound)
     }
 
-    pub fn resolve_version(&self, version: &str) -> Result<Version> {
+    /// Parse `version` as semver, or resolve `"latest"` via `latest_release`.
+    pub async fn resolve_version(&self, version: &str) -> Result<Version> {
         if version == "latest" {
-            self.latest_release()
+            self.latest_release().await
         } else {
             Version::parse(version).context(SemVerSnafu {})
         }
@@ -488,6 +498,23 @@ pub fn runtime_ge_015(runtime: &str) -> bool {
     semver::Version::parse(runtime)
         .map(|v| v >= semver::Version::new(0, 15, 0))
         .unwrap_or(true)
+}
+
+/// Run the synchronous git2-based release enumeration on a blocking worker.
+///
+/// `releases::get_all` internally calls `git2::Remote::connect` and
+/// `Remote::list`, both of which perform blocking network I/O. Running them
+/// on the tokio runtime directly would stall other async tasks for the
+/// duration of the git protocol handshake, so we hop to a blocking thread.
+async fn fetch_releases_blocking(filter: ReleasesFilter) -> Result<Vec<Version>> {
+    match tokio::task::spawn_blocking(move || releases::get_all(WASMEDGE_GIT_URL, filter)).await {
+        Ok(inner) => inner,
+        Err(join_err) => Err(Error::Io {
+            action: "release-enumeration task".to_string(),
+            path: WASMEDGE_GIT_URL.to_string(),
+            source: crate::error::join_err_to_io_error(join_err),
+        }),
+    }
 }
 
 /// Metadata describing a single plugin release asset as published on

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -73,9 +73,13 @@ impl CommandExecutor for InstallArgs {
     /// or copying issues.
     #[tracing::instrument(name = "install", skip_all, fields(version = self.version))]
     async fn execute(mut self, ctx: CommandContext) -> Result<()> {
-        let version = ctx.client.resolve_version(&self.version).inspect_err(
-            |e| tracing::error!(error = %e.to_string(), "Failed to resolve version"),
-        )?;
+        let version = ctx
+            .client
+            .resolve_version(&self.version)
+            .await
+            .inspect_err(
+                |e| tracing::error!(error = %e.to_string(), "Failed to resolve version"),
+            )?;
         tracing::debug!(%version, "Resolved version for installation");
 
         let os = self.os.get_or_insert_default();
@@ -126,7 +130,7 @@ impl CommandExecutor for InstallArgs {
         }
 
         tracing::debug!(dest = %tmpdir.display(), "Starting extraction of asset");
-        crate::fs::extract_archive(&mut file, &tmpdir)
+        crate::fs::extract_archive(file, &tmpdir)
             .await
             .inspect_err(|e| tracing::error!(error = %e.to_string(), "Failed to extract asset"))?;
         tracing::debug!(dest = %tmpdir.display(), "Extraction completed successfully");

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -31,8 +31,8 @@ impl CommandExecutor for ListArgs {
                 ReleasesFilter::Stable
             };
 
-            let releases = ctx.client.releases(filter, 10)?;
-            let latest_release = ctx.client.latest_release()?;
+            let releases = ctx.client.releases(filter, 10).await?;
+            let latest_release = ctx.client.latest_release().await?;
 
             for gh_release in releases.into_iter() {
                 print!("{gh_release}");

--- a/src/commands/plugin/install.rs
+++ b/src/commands/plugin/install.rs
@@ -163,7 +163,7 @@ impl CommandExecutor for PluginInstallArgs {
                 tracing::debug!(plugin = %name, "Plugin checksum verified");
             }
 
-            wfs::extract_archive(&mut file, &workspace).await?;
+            wfs::extract_archive(file, &workspace).await?;
 
             let paths = find_plugin_shared_objects(&workspace);
             let found_any = if !paths.is_empty() {

--- a/src/commands/remove.rs
+++ b/src/commands/remove.rs
@@ -103,9 +103,13 @@ impl CommandExecutor for RemoveArgs {
             return Ok(());
         }
 
-        let version = ctx.client.resolve_version(&self.version).inspect_err(
-            |e| tracing::error!(error = %e.to_string(), "Failed to resolve version"),
-        )?;
+        let version = ctx
+            .client
+            .resolve_version(&self.version)
+            .await
+            .inspect_err(
+                |e| tracing::error!(error = %e.to_string(), "Failed to resolve version"),
+            )?;
         tracing::debug!(%version, "Resolved version for use");
 
         let version_dir = versions_dir.join(version.to_string());

--- a/src/error.rs
+++ b/src/error.rs
@@ -105,3 +105,93 @@ pub enum Error {
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
+
+/// Convert a [`tokio::task::JoinError`] into a [`std::io::Error`] without
+/// losing diagnostic context.
+///
+/// `JoinError`'s `Display` impl renders only `"task was cancelled"` or
+/// `"task panicked"` — the panic payload is stored separately in the
+/// internal `Box<dyn Any + Send>` and is unreachable through `to_string()`.
+/// The previous call sites used `std::io::Error::other(join_err.to_string())`,
+/// which both stringified prematurely *and* discarded the panic payload.
+///
+/// This helper:
+///
+/// - For panics: extracts the payload via [`JoinError::try_into_panic`] and
+///   includes the message in the resulting `io::Error` (handling both the
+///   `&'static str` and `String` cases that `panic!` produces in practice).
+/// - For cancellations: preserves the original `JoinError` as the `io::Error`
+///   source, so downstream callers can still downcast and inspect via
+///   `io_err.get_ref()`.
+pub(crate) fn join_err_to_io_error(join_err: tokio::task::JoinError) -> std::io::Error {
+    if join_err.is_panic() {
+        // Documented contract: when is_panic() is true, try_into_panic returns
+        // Ok. The Err arm here is defense-in-depth for future tokio changes.
+        let payload = match join_err.try_into_panic() {
+            Ok(p) => p,
+            Err(_) => return std::io::Error::other("blocking task panicked (payload unavailable)"),
+        };
+        let msg = if let Some(s) = payload.downcast_ref::<&'static str>() {
+            (*s).to_string()
+        } else if let Some(s) = payload.downcast_ref::<String>() {
+            s.clone()
+        } else {
+            "<non-string panic payload>".to_string()
+        };
+        std::io::Error::other(format!("blocking task panicked: {msg}"))
+    } else {
+        // Cancellation: preserve the JoinError as source so callers can
+        // still downcast it (io_err.get_ref().and_then(|e| e.downcast_ref())).
+        std::io::Error::other(join_err)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn join_err_to_io_extracts_str_panic_payload() {
+        let join_err = tokio::task::spawn_blocking(|| panic!("custom panic literal"))
+            .await
+            .expect_err("the task panicked, so awaiting must yield Err");
+        let io_err = join_err_to_io_error(join_err);
+        assert!(
+            io_err.to_string().contains("custom panic literal"),
+            "io_err display `{io_err}` should include the &'static str payload"
+        );
+    }
+
+    #[tokio::test]
+    async fn join_err_to_io_extracts_string_panic_payload() {
+        let join_err = tokio::task::spawn_blocking(|| panic!("formatted panic: {}", 42))
+            .await
+            .expect_err("the task panicked, so awaiting must yield Err");
+        let io_err = join_err_to_io_error(join_err);
+        assert!(
+            io_err.to_string().contains("42"),
+            "io_err display `{io_err}` should include the formatted String payload"
+        );
+    }
+
+    #[tokio::test]
+    async fn join_err_to_io_preserves_cancellation_as_source() {
+        let handle = tokio::task::spawn(async {
+            tokio::time::sleep(std::time::Duration::from_secs(60)).await;
+        });
+        handle.abort();
+        let join_err = handle.await.expect_err("aborted task must yield Err");
+        assert!(
+            join_err.is_cancelled(),
+            "test setup: must be a cancellation"
+        );
+        let io_err = join_err_to_io_error(join_err);
+        let source = io_err
+            .get_ref()
+            .expect("cancellation path should preserve the JoinError as source");
+        assert!(
+            source.to_string().contains("cancel"),
+            "source display `{source}` should mention cancellation"
+        );
+    }
+}

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -334,32 +334,40 @@ fn create_symlink_windows(target: &Path, link: &Path, is_dir: bool) -> Result<()
     })
 }
 
-/// Extracts the contents of a compressed archive (`.tar.gz` for Unix-like systems, `.zip` for Windows) to a specified directory.
-///
-/// # Arguments
-///
-/// * `file` - A file object representing the compressed archive. This file must be opened in read mode.
-/// * `dest` - The destination directory to which the contents will be extracted.
-///
-/// # Errors
-///
-/// Returns an error if the extraction fails. This could happen if the archive format is unsupported or
-/// if the destination path cannot be created.
-pub async fn extract_archive(file: &mut std::fs::File, dest: &Path) -> Result<()> {
+/// Extract a compressed archive (`.tar.gz` on Unix, `.zip` on Windows) to
+/// `dest`. The file ownership is consumed because the synchronous
+/// extraction runs on a blocking worker via [`tokio::task::spawn_blocking`],
+/// so the tokio main runtime stays free to make progress on other async
+/// tasks while tar/zip decoding proceeds (unpacking a ~80MB runtime bundle
+/// can take seconds).
+pub async fn extract_archive(file: std::fs::File, dest: &Path) -> Result<()> {
     fs::create_dir_all(dest).await.inspect_err(
         |e| tracing::error!(error = %e.to_string(), "Failed to create directory during extraction"),
     )?;
+
+    let dest_buf = dest.to_path_buf();
+    match tokio::task::spawn_blocking(move || extract_archive_blocking(file, &dest_buf)).await {
+        Ok(inner) => inner,
+        Err(join_err) => Err(Error::Io {
+            action: "archive extraction task".to_string(),
+            path: dest.display().to_string(),
+            source: crate::error::join_err_to_io_error(join_err),
+        }),
+    }
+}
+
+fn extract_archive_blocking(mut file: std::fs::File, dest: &Path) -> Result<()> {
     file.rewind()?;
 
     #[cfg(unix)]
     {
         use flate2::read::GzDecoder;
-        let decompressed = GzDecoder::new(file);
+        let decompressed = GzDecoder::new(&mut file);
         extract_tar(decompressed, dest)?;
     }
 
     #[cfg(windows)]
-    extract_zip(file, dest)?;
+    extract_zip(&mut file, dest)?;
 
     Ok(())
 }

--- a/tests/client_test.rs
+++ b/tests/client_test.rs
@@ -82,7 +82,7 @@ fn test_latest_installed_version_prerelease() {
 #[tokio::test]
 async fn test_get_release_checksum() {
     let client = WasmEdgeApiClient::default();
-    let version = client.latest_release().unwrap();
+    let version = client.latest_release().await.unwrap();
     let mut args = InstallArgs {
         version: "latest".to_string(),
         path: None,

--- a/tests/plugin_install_test.rs
+++ b/tests/plugin_install_test.rs
@@ -86,6 +86,7 @@ async fn run_plugin_install_smoke(no_verify: bool) {
     let client = WasmEdgeApiClient::default();
     let resolved_version = client
         .resolve_version(&version)
+        .await
         .expect("resolve latest failed");
 
     let specs = system::detect();


### PR DESCRIPTION
## Which GitHub issue does this PR close?

N/A — tenth in the incremental refactor series (follows #271).

## Why is this needed?

Two functions in the codebase were lying about being `async`. Their
signatures said `async fn`, but their bodies ran blocking work directly
on the tokio worker thread that polled them — starving every other task
sharing that worker for the duration.

`async fn` only marks the function as returning a `Future`; it does
**not** enforce that the body yields. The compiler accepts a sync
`tar::Archive::unpack` inside `async fn` happily, and at runtime the
extraction blocks the worker for seconds. Only careful auditing or a
runtime tool like `tokio-console` would catch this — and the
consequence today is that progress bars freeze, log lines stop
draining, and cancellation hooks don't fire while a runtime install or
plugin install is unpacking a multi-megabyte archive.

This PR makes both functions honest. Same data in, same data out, but
the tokio runtime can now make progress on other tasks during the slow
operations.

## What does this PR change?

### 1. `fs::extract_archive`

Previously: `async fn extract_archive(file: &mut std::fs::File, dest:
&Path) -> Result<()>` whose body ran `tar::Archive::unpack(...)` (Unix)
or `zip::ZipArchive::extract(...)` (Windows) synchronously.

Now:

- Takes `file: std::fs::File` by value (callers did not need the file
  after extraction anyway, so this is a no-op for them at the callsite).
- Dispatches a new private synchronous helper, `extract_archive_blocking`,
  through `tokio::task::spawn_blocking`. The blocking helper takes
  ownership of the `File` and the destination `PathBuf` (both `'static`),
  which is the constraint `spawn_blocking` imposes.
- Maps `JoinError` to `Error::Io` so a panic in the blocking task is
  surfaced rather than swallowed.

### 2. `WasmEdgeApiClient::releases` / `latest_release` / `resolve_version`

Previously sync methods that called into `git2::Remote::connect`
(blocking network I/O for the git protocol handshake) from inside the
`async` `execute` methods of the install/remove/list commands.

Now:

- All three are `async` and delegate to a new private
  `fetch_releases_blocking` helper, which runs the git2 work inside
  `spawn_blocking`.
- Call sites updated to `.await` them: `commands/install.rs`,
  `commands/remove.rs`, `commands/list.rs`, `commands/plugin/install.rs`,
  plus `tests/client_test.rs` and `tests/plugin_install_test.rs`.

## How has this been tested?

- `cargo fmt --all --check` ✅
- `cargo clippy --all --all-features --tests -- -D warnings` ✅
- `cargo test` ✅ — full suite, including the live-network
  `version_test` and `client_test` integration tests that exercise the
  newly-async git2 path, and the install/plugin-install integration
  tests that exercise the new extraction blocking helper.
- `lineguard` ✅ across all 8 touched files.

No observable behavior change — same git refs returned, same archives
extracted — but the runtime is no longer blocked during them.

## Anything else?

Tenth PR in the incremental refactor series. Two more remain:
PR #11 (`refactor/phase-08-which-dedupe`) and PR #12
(`refactor/phase-09-plugin-list-decompose`).