### PR TITLE
refactor: consolidate duplicate which() helpers

### DIFF
--- a/src/system/gpu.rs
+++ b/src/system/gpu.rs
@@ -3,6 +3,8 @@ use crate::system::spec::OpenClDeviceSpec;
 use crate::system::spec::{AcceleratorSupport, CudaSpec, GpuSpec, GpuVendor};
 #[cfg(unix)]
 use crate::system::spec::{OpenClDeviceSpec, RocmSpec};
+use crate::system::which_bin;
+#[cfg(unix)]
 use std::path::PathBuf;
 
 #[cfg(unix)]
@@ -38,12 +40,12 @@ pub fn detect_gpu() -> (Vec<GpuSpec>, AcceleratorSupport, Vec<String>, Vec<Strin
     let mut errors = Vec::new();
 
     #[cfg(unix)]
-    let nvidia_smi = which("nvidia-smi");
+    let nvidia_smi = which_bin("nvidia-smi");
     #[cfg(unix)]
-    let rocminfo = which("rocminfo");
+    let rocminfo = which_bin("rocminfo");
     #[cfg(unix)]
-    let clinfo = which("clinfo");
-    let vulkaninfo = which("vulkaninfo");
+    let clinfo = which_bin("clinfo");
+    let vulkaninfo = which_bin("vulkaninfo");
 
     let mut gpus: Vec<GpuSpec> = Vec::new();
 
@@ -242,19 +244,6 @@ fn vendor_from_str(s: &str) -> GpuVendor {
     } else {
         GpuVendor::Other
     }
-}
-
-fn which(bin: &str) -> Option<PathBuf> {
-    std::env::var_os("PATH").and_then(|paths| {
-        std::env::split_paths(&paths).find_map(|p| {
-            let candidate = p.join(bin);
-            if candidate.exists() {
-                Some(candidate)
-            } else {
-                None
-            }
-        })
-    })
 }
 
 #[cfg(unix)]

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -11,3 +11,21 @@ pub use spec::{
     AcceleratorSupport, CpuClass, CpuFeature, CpuSpec, CudaSpec, GpuSpec, GpuVendor, LibcKind,
     LibcSpec, OpenClDeviceSpec, OsSpec, RocmSpec, SystemSpec, ToolchainSpec,
 };
+
+/// Resolve `bin` via the OS `PATH` and return the path to the executable
+/// as reported by the [`which`] crate, or `None` if no match is found.
+///
+/// On Windows the resolution honours `PATHEXT`, so passing a bare name
+/// like `"wasmedge"` will locate `wasmedge.exe` (or any other configured
+/// executable suffix). The returned path is whatever `which::which`
+/// produces — usually absolute, but in unusual setups it may be relative
+/// (e.g. when `PATH` contains relative entries, or when `bin` already
+/// contains path separators and is used as-is). Callers that need a
+/// canonical absolute form should layer their own `canonicalize()` on top.
+///
+/// Thin wrapper over the `which` crate so detection code doesn't have to
+/// import it directly, and so gpu/toolchain modules no longer maintain
+/// parallel copies of the same helper.
+pub(crate) fn which_bin(bin: &str) -> Option<std::path::PathBuf> {
+    which::which(bin).ok()
+}

--- a/src/system/toolchain.rs
+++ b/src/system/toolchain.rs
@@ -1,5 +1,5 @@
 use crate::system::spec::{LibcKind, ToolchainSpec};
-use std::path::PathBuf;
+use crate::system::which_bin;
 use std::process::Command;
 
 pub fn detect_toolchain(
@@ -9,36 +9,17 @@ pub fn detect_toolchain(
     let notes = Vec::new();
     let errors = Vec::new();
 
-    let nvidia_smi_path = which("nvidia-smi");
-    let nvcc_path = which("nvcc");
-    let rocminfo_path = which("rocminfo");
-    let clinfo_path = which("clinfo");
-    let vulkaninfo_path = which("vulkaninfo");
-
     let toolchain = ToolchainSpec {
-        nvidia_smi_path,
-        nvcc_path,
-        rocminfo_path,
-        clinfo_path,
-        vulkaninfo_path,
+        nvidia_smi_path: which_bin("nvidia-smi"),
+        nvcc_path: which_bin("nvcc"),
+        rocminfo_path: which_bin("rocminfo"),
+        clinfo_path: which_bin("clinfo"),
+        vulkaninfo_path: which_bin("vulkaninfo"),
         libc_kind,
         libc_version,
     };
 
     (toolchain, notes, errors)
-}
-
-fn which(bin: &str) -> Option<PathBuf> {
-    std::env::var_os("PATH").and_then(|paths| {
-        std::env::split_paths(&paths).find_map(|p| {
-            let candidate = p.join(bin);
-            if candidate.exists() {
-                Some(candidate)
-            } else {
-                None
-            }
-        })
-    })
 }
 
 /// Runs `wasmedge --version` and extracts the reported version string.


### PR DESCRIPTION
## Which GitHub issue does this PR close?

N/A — eleventh in the incremental refactor series (follows #272).

## Why is this needed?

`src/system/gpu.rs` and `src/system/toolchain.rs` each carried a
private, byte-identical hand-rolled `which()` that walked `PATH`
manually with per-entry stat checks. This crate already depends on the
`which` crate transitively, so the hand-rolled version was strictly
worse than the existing dependency: more code to maintain, two copies
that would inevitably drift over time, and — most importantly — a
**latent Windows bug**.

The hand-rolled helpers searched `PATH` literally. On Windows, the
mechanism that turns `wasmedge` into `wasmedge.exe` (or `.bat`, `.cmd`,
…) is the **`PATHEXT`** environment variable, which is *separate* from
`PATH`. A naive PATH-only walker silently misses every Windows
binary. The `which` crate handles `PATHEXT` resolution correctly, so
moving to it fixes this without anyone having to ask.

## What does this PR change?

- **`src/system/mod.rs`**: adds
  `pub(crate) fn which_bin(bin: &str) -> Option<PathBuf>` wrapping
  `which::which(bin).ok()`. The `pub(crate)` visibility is deliberate —
  this is CLI-internal infrastructure with no library-API stability
  needs.
- **`src/system/gpu.rs`**: replaces 4 call sites
  (`nvidia-smi`, `rocminfo`, `clinfo`, `vulkaninfo`) and deletes the
  local helper.
- **`src/system/toolchain.rs`**: replaces 5 call sites
  (`nvidia-smi`, `nvcc`, `rocminfo`, `clinfo`, `vulkaninfo`) and
  deletes the local helper.

Net diff: **+21 / −42** across 3 files. No new dependencies.

## How has this been tested?

- `cargo fmt --all --check` ✅
- `cargo clippy --all --all-features --tests -- -D warnings` ✅
- `cargo test` ✅ — full suite, including the live-network and
  filesystem integration tests that exercise the GPU/toolchain probe
  paths through the public command surface.
- `lineguard` ✅ across all 3 touched files.

The Windows `PATHEXT` fix is implicit — there's no behavioral test for
it in this repo, but the existing CI matrix exercises Windows on every
PR and would surface a regression if `which::which` ever stopped
resolving `.exe` on Windows.

## Anything else?

Eleventh PR in the incremental refactor series. One PR remains:
PR #12 (`refactor/phase-09-plugin-list-decompose`).