### PR TITLE
ci: align rust and release workflows on cross-compile build

### DIFF
--- a/.github/actions/cross-compile-prelude/action.yml
+++ b/.github/actions/cross-compile-prelude/action.yml
@@ -1,0 +1,21 @@
+name: Cross-compile prerequisites
+description: Install target-specific build prerequisites shared by the Rust CI and Release workflows. Keeps the two workflows from drifting on cross-compile setup.
+
+inputs:
+  target:
+    description: Build target triple (e.g. x86_64-unknown-linux-musl, aarch64-unknown-linux-gnu)
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Install musl-tools (x86_64-unknown-linux-musl)
+      if: inputs.target == 'x86_64-unknown-linux-musl'
+      shell: bash
+      run: sudo apt-get install -y musl-tools
+
+    - name: Setup cross-compilation toolchain (aarch64 Linux)
+      if: inputs.target == 'aarch64-unknown-linux-gnu' || inputs.target == 'aarch64-unknown-linux-musl'
+      uses: taiki-e/setup-cross-toolchain-action@129361238c06ff2cc1c4ca5c5d2217af441ffdf6 # v1
+      with:
+        target: ${{ inputs.target }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,13 +45,8 @@ jobs:
         with:
           target: ${{ matrix.target }}
 
-      - name: Install musl-tools (x86_64)
-        if: matrix.target == 'x86_64-unknown-linux-musl'
-        run: sudo apt-get install -y musl-tools
-
-      - name: Setup cross-compilation toolchain
-        if: matrix.target == 'aarch64-unknown-linux-gnu' || matrix.target == 'aarch64-unknown-linux-musl'
-        uses: taiki-e/setup-cross-toolchain-action@129361238c06ff2cc1c4ca5c5d2217af441ffdf6 # v1
+      - name: Cross-compile prerequisites
+        uses: ./.github/actions/cross-compile-prelude
         with:
           target: ${{ matrix.target }}
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -103,6 +103,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
           - target: x86_64-unknown-linux-musl
             os: ubuntu-latest
           - target: aarch64-unknown-linux-gnu
@@ -130,15 +132,10 @@ jobs:
         with:
           target: ${{ matrix.target }}
 
-      - name: Install musl-tools (x86_64)
-        if: matrix.target == 'x86_64-unknown-linux-musl'
-        run: sudo apt-get install -y musl-tools
-
-      - name: Setup cross-compilation toolchain
-        if: matrix.target == 'aarch64-unknown-linux-gnu' || matrix.target == 'aarch64-unknown-linux-musl'
-        uses: taiki-e/setup-cross-toolchain-action@129361238c06ff2cc1c4ca5c5d2217af441ffdf6 # v1
+      - name: Cross-compile prerequisites
+        uses: ./.github/actions/cross-compile-prelude
         with:
           target: ${{ matrix.target }}
 
-      - name: Build check
-        run: cargo check --target ${{ matrix.target }}
+      - name: Build (release)
+        run: cargo build --release --target ${{ matrix.target }}


### PR DESCRIPTION
## Summary

- Closes the gap between **rust.yml** (CI) and **release.yml** (Release) so a release-mode build failure can no longer slip past PR review.
- Extracts the cross-compile prereqs (`musl-tools` install, `setup-cross-toolchain-action`) into a single composite action under `.github/actions/cross-compile-prelude/`, so the two workflows physically share the same source of truth.
- Brings the CI `cross-build` job up to parity with Release on **target list** and **build command**.

## What was diverging

| | `rust.yml` cross-build (before) | `release.yml` build-artifacts |
|---|---|---|
| Target list | 6 targets | 7 targets (+ `x86_64-unknown-linux-gnu`) |
| Build command | `cargo check --target …` | `cargo build --release --target …` |
| Prereq steps | inline (`musl-tools`, ARM toolchain) | inline (`musl-tools`, ARM toolchain) — same content, separate definition |

The asymmetry meant CI used a faster, less thorough build (`cargo check`) on a smaller matrix, so release-only failure modes — linker errors, `[profile.release]` codegen issues, target-specific cfg fallout — could land on `master` and then explode at release time. After the gix migration in #275, which reshapes the link surface, that gap is more relevant.

## Changes

- **New composite action** `.github/actions/cross-compile-prelude/action.yml`: installs `musl-tools` on `x86_64-unknown-linux-musl`, runs `taiki-e/setup-cross-toolchain-action` on the two aarch64 Linux targets, no-op otherwise.
- `rust.yml` `cross-build`:
  - Adds `x86_64-unknown-linux-gnu` to the matrix.
  - Replaces inline prereq steps with the composite.
  - Switches `cargo check --target …` to `cargo build --release --target …` so CI exercises the exact build command Release uses.
- `release.yml` `build-artifacts`: replaces the inline prereq steps with the composite. Build command was already correct.

## Trade-off

PR CI now does full release-mode cross-compile builds for all 7 targets. The `setup-rust` composite action already wires `sccache`, so the cold-cache penalty is paid once per cache miss and warm runs stay close to prior duration. Net: slower first run, similar steady-state, much stronger guarantee that `master` builds at release.

## Test plan

- [x] Local YAML sanity check on all three changed files (no tabs, trailing newlines).
- [x] `lineguard` clean on all three files.
- [ ] CI run on this PR exercises the new composite action and the broader matrix end-to-end.
- [ ] Confirm the `cross-build` matrix shows all 7 targets in the GitHub Actions UI for this PR.