### PR TITLE
fix(api): skip stable tags whose GitHub Release is not yet published

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -58,11 +58,135 @@ impl WasmEdgeApiClient {
         Ok(releases.into_iter().take(num_releases).collect())
     }
 
-    /// Fetch the newest stable WasmEdge release via a `spawn_blocking` wrapper
-    /// around the blocking git2 remote call.
+    /// Returns the newest stable version whose **install assets are
+    /// actually available** on the release CDN.
+    ///
+    /// `releases::get_all` enumerates every git tag matching the stable
+    /// semver shape, but a tag can exist before its install artefacts
+    /// are uploaded:
+    ///
+    /// 1. Maintainers push a tag to mark a revision and trigger CI.
+    /// 2. CI builds Linux/macOS/Windows archives plus the SHA256SUM
+    ///    digest file, then a GitHub Release is published with those
+    ///    assets attached. The Release may be created as a *draft*
+    ///    while assets are uploading.
+    ///
+    /// During phase 1 (and during the draft window of phase 2) the tag
+    /// is "latest stable" by name only — `wasmedgeup install latest`
+    /// would 404 on the SHA256SUM download. To pick the version users
+    /// can actually install, we walk candidates newest-first and accept
+    /// the first one whose SHA256SUM file is reachable on the release
+    /// CDN.
+    ///
+    /// Why HEAD the CDN file instead of querying
+    /// `/repos/.../releases/tags/<tag>`: the REST endpoint is gated by
+    /// GitHub's 60-req/hour unauthenticated rate limit, which CI
+    /// runners on shared IPs hit easily — manifesting as 403 spuriously
+    /// reported as "release missing." The release-download URL is
+    /// served by GitHub's CDN with no API rate limit, so the check is
+    /// both cheaper and more reliable. It also incidentally handles the
+    /// draft case: a draft Release exposes no asset URLs to the public
+    /// CDN, so the HEAD naturally 404s.
     pub async fn latest_release(&self) -> Result<Version> {
-        let releases = fetch_releases_blocking(ReleasesFilter::Stable).await?;
-        releases.into_iter().next().ok_or(Error::NoReleasesFound)
+        let candidates = fetch_releases_blocking(ReleasesFilter::Stable).await?;
+        if candidates.is_empty() {
+            return Err(Error::NoReleasesFound);
+        }
+        // Build the HTTP client once and reuse it across every candidate
+        // check so connection pooling and TLS sessions amortise across
+        // the walk during release-prep windows. Each candidate makes
+        // either one HEAD or a HEAD+GET pair; without reuse, every
+        // candidate would pay full TCP+TLS handshake cost.
+        let client = self.http_client()?;
+        for candidate in candidates {
+            if Self::is_release_published(&client, &candidate.to_string()).await? {
+                return Ok(candidate);
+            }
+            tracing::debug!(
+                version = %candidate,
+                "stable tag has no published assets yet — skipping"
+            );
+        }
+        Err(Error::NoPublishedReleasesFound)
+    }
+
+    /// Returns `true` if `tag`'s release SHA256SUM file is downloadable.
+    ///
+    /// The check follows redirects (the github.com release URL 302s to
+    /// the actual CDN object). 404 means the tag has no published
+    /// assets yet — either no Release at all, or a draft Release whose
+    /// assets have not been uploaded.
+    ///
+    /// We try `HEAD` first because it skips the body, but fall back to
+    /// `GET` whenever the `HEAD` doesn't yield a definitive answer.
+    /// Two failure modes both trigger the fallback:
+    ///
+    /// 1. HEAD returns a response with a non-404 non-2xx status — some
+    ///    proxies and CDN edges reject HEAD specifically (commonly 403
+    ///    or 405) while serving the same GET cleanly.
+    /// 2. HEAD's transport itself fails — WAFs configured for a
+    ///    method allow-list will drop HEAD at the network layer, which
+    ///    surfaces as a reqwest `Err` (TCP reset, timeout, etc.)
+    ///    rather than a status code.
+    ///
+    /// Treating both as "HEAD inconclusive, retry GET" matches the
+    /// resilience of `head_ok` and keeps `wasmedgeup install latest`
+    /// and `wasmedgeup list --remote` working behind such
+    /// intermediaries. Truly fatal outcomes on the `GET` arm (5xx,
+    /// transport errors, real auth failures) propagate so transient
+    /// outages surface honestly rather than as misleading
+    /// `NoReleasesFound`.
+    async fn is_release_published(client: &Client, tag: &str) -> Result<bool> {
+        let url = Self::checksum_url(tag);
+
+        match client.head(url.clone()).send().await {
+            Ok(head) if is_missing_status(head.status()) => return Ok(false),
+            Ok(head) if head.status().is_success() => return Ok(true),
+            Ok(head) => tracing::debug!(
+                status = %head.status(),
+                tag,
+                "HEAD on SHA256SUM was rejected; retrying as GET",
+            ),
+            Err(e) => tracing::debug!(
+                error = %e,
+                tag,
+                "HEAD on SHA256SUM failed at transport; retrying as GET",
+            ),
+        }
+
+        let get = client.get(url).send().await.context(RequestSnafu {
+            resource: "release publication check",
+        })?;
+        let status = get.status();
+        if is_missing_status(status) {
+            // Drain the body so hyper can return the underlying connection
+            // to the pool. Dropping the response without reading the body
+            // taints the socket as non-reusable, which would silently
+            // negate the `Client` reuse in `latest_release()` whenever the
+            // GET fallback fires (i.e. exactly the case where pool reuse
+            // matters).
+            let _ = get.bytes().await;
+            return Ok(false);
+        }
+        let resp = get.error_for_status().context(RequestSnafu {
+            resource: "release publication check",
+        })?;
+        // Same body-draining contract on the success path.
+        let _ = resp.bytes().await;
+        Ok(true)
+    }
+
+    /// Build the URL for `tag`'s release SHA256SUM file. Shared between
+    /// `is_release_published` (HEAD/GET reachability check) and
+    /// `get_archive_checksum` (real download), so any future change to
+    /// the release URL scheme touches one place.
+    fn checksum_url(tag: &str) -> Url {
+        let mut url = Url::parse(WASMEDGE_RELEASE_BASE_URL)
+            .expect("WASMEDGE_RELEASE_BASE_URL must be a valid URL");
+        url.path_segments_mut()
+            .expect("base is valid URL")
+            .extend(&[tag, CHECKSUM_FILE_NAME]);
+        url
     }
 
     /// Parse `version` as semver, or resolve `"latest"` via `latest_release`.
@@ -104,12 +228,7 @@ impl WasmEdgeApiClient {
     /// release tag that lists hashes for both runtime archives and plugin
     /// archives, so the same lookup serves both installer paths.
     pub async fn get_archive_checksum(&self, tag: &str, archive_name: &str) -> Result<String> {
-        let mut url = Url::parse(WASMEDGE_RELEASE_BASE_URL)
-            .expect("WASMEDGE_RELEASE_BASE_URL must be a valid URL");
-
-        url.path_segments_mut()
-            .expect("base is valid URL")
-            .extend(&[tag, CHECKSUM_FILE_NAME]);
+        let url = Self::checksum_url(tag);
 
         tracing::debug!(%url, CHECKSUM_FILE_NAME, "Trying checksum file");
 
@@ -123,10 +242,7 @@ impl WasmEdgeApiClient {
         // statuses (403 rate-limit, 5xx outage) are operational errors and
         // propagate via Error::Request so the user sees the actual status
         // instead of a misleading "checksum not found".
-        if matches!(
-            response.status(),
-            reqwest::StatusCode::NOT_FOUND | reqwest::StatusCode::GONE
-        ) {
+        if is_missing_status(response.status()) {
             tracing::debug!(
                 status = %response.status(),
                 file = CHECKSUM_FILE_NAME,
@@ -498,6 +614,21 @@ pub fn runtime_ge_015(runtime: &str) -> bool {
     semver::Version::parse(runtime)
         .map(|v| v >= semver::Version::new(0, 15, 0))
         .unwrap_or(true)
+}
+
+/// Returns `true` for HTTP statuses that signal "this asset is not (or no
+/// longer) available." Currently `404 Not Found` (never published) and
+/// `410 Gone` (explicitly removed). Shared between the publication probe
+/// in `is_release_published` and the real download in
+/// `get_archive_checksum` so both functions agree on what "missing"
+/// means — that way deleting an old release doesn't make the publication
+/// probe abort `latest_release` while the equivalent download path
+/// still treats it as "missing checksum, fall through".
+fn is_missing_status(status: reqwest::StatusCode) -> bool {
+    matches!(
+        status,
+        reqwest::StatusCode::NOT_FOUND | reqwest::StatusCode::GONE
+    )
 }
 
 /// Run the synchronous git2-based release enumeration on a blocking worker.

--- a/src/error.rs
+++ b/src/error.rs
@@ -85,6 +85,13 @@ pub enum Error {
     #[snafu(display("No WasmEdge releases were found"))]
     NoReleasesFound,
 
+    #[snafu(display(
+        "No installable stable WasmEdge release was found.\n\
+         The most recent stable tag(s) exist in git but their release assets are not yet published.\n\
+         Retry shortly, or install a specific version with `wasmedgeup install <version>`."
+    ))]
+    NoPublishedReleasesFound,
+
     #[snafu(display("No plugins specified for installation"))]
     NoPluginsSpecified,
 
@@ -149,6 +156,30 @@ pub(crate) fn join_err_to_io_error(join_err: tokio::task::JoinError) -> std::io:
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn no_published_releases_found_renders_without_indentation() {
+        // Regression test for the `\<newline>` line-continuation pattern
+        // used in the multi-line `Display` for `NoPublishedReleasesFound`.
+        // Rust's reference (string-literal grammar) specifies that
+        // `\<newline>` and the following whitespace are dropped, so the
+        // continued lines must NOT carry the source-level indentation.
+        let msg = Error::NoPublishedReleasesFound.to_string();
+        for (i, line) in msg.lines().enumerate() {
+            assert!(
+                !line.starts_with(' ') && !line.starts_with('\t'),
+                "line {i} of NoPublishedReleasesFound display unexpectedly indented: {line:?}",
+            );
+        }
+        assert!(
+            msg.contains("Retry shortly"),
+            "actionable hint missing from message: {msg:?}",
+        );
+        assert!(
+            msg.contains("`wasmedgeup install <version>`"),
+            "actionable hint missing from message: {msg:?}",
+        );
+    }
 
     #[tokio::test]
     async fn join_err_to_io_extracts_str_panic_payload() {

--- a/tests/install_test.rs
+++ b/tests/install_test.rs
@@ -81,16 +81,19 @@ async fn test_install_latest_version() {
     let tmpdir = tempdir().unwrap();
     let install_dir = tmpdir.path().join("install_target");
 
-    let all_releases = releases::get_all(WASM_EDGE_GIT_URL, ReleasesFilter::Stable).unwrap();
-    assert!(!all_releases.is_empty());
-
     let (_tempdir, _test_home) = setup_test_environment();
     #[cfg(windows)]
     {
         // Give Windows a moment to release any file handles
         std::thread::sleep(std::time::Duration::from_millis(100));
     }
-    execute_install_test(all_releases[0].to_string(), install_dir, tmpdir, false).await;
+    // Pass "latest" through the same resolution path users hit so the test
+    // exercises `latest_release()` end-to-end. Picking `releases::get_all`'s
+    // first element directly would re-create the bug where a stable git
+    // tag (e.g. 0.16.3) is reported as latest before its GitHub Release
+    // is published, even though `latest_release()` already filters those
+    // out.
+    execute_install_test("latest".to_string(), install_dir, tmpdir, false).await;
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Fixes `latest_release()` to return the latest stable version whose **install assets are actually uploaded** to the release CDN, not just the latest stable git tag. The two diverge during release-prep windows when a tag is pushed but its archives are still being built / a draft Release exists without published assets.

## Root cause

WasmEdge releases happen in two phases:

| Phase | What happens | Visible to |
|---|---|---|
| **1. Tag push** | Maintainers push a tag like `0.16.3` to mark a revision and trigger CI. | `git ls-remote` immediately. |
| **2. Release publish** | CI builds Linux/macOS/Windows archives + the `SHA256SUM` digest, then a GitHub Release goes live with assets attached. The Release may be a *draft* during the upload window. | `releases/tags/<tag>` REST endpoint and asset CDN URLs. |

`latest_release()` was reading from phase 1 (`releases::get_all` → `git ls-remote`). Whenever phase 2 hadn't completed for the highest tag, callers that subsequently tried to download anything (`get_release_checksum`, `wasmedgeup install latest`, the `<- latest` marker in `wasmedgeup list --remote`) would fail with `ChecksumNotFound`.

This bug is independent of the recent gix migration — the previous `git2::Remote::list` path had the same conflation between "latest tag" and "latest installable release."

## Fix: HEAD the CDN, not the API

`latest_release()` now walks sorted stable candidates newest-first and accepts the first one whose `SHA256SUM` file is reachable via `HEAD <WASMEDGE_RELEASE_BASE_URL>/<tag>/SHA256SUM`. A 404 → fall through to the next candidate; other non-2xx → propagate.

**Why HEAD-on-CDN rather than `GET /repos/.../releases/tags/<tag>`:** the REST endpoint is gated by GitHub's 60-req/hour unauthenticated rate limit. CI runners share IPs and our other tests already hit that API, so the publication check would land 403 — surfacing as a misleading "release publication check" error rather than as "not published yet." The release-download URL is served by GitHub's CDN with no API rate limit, so the check is both cheaper and more reliable. It also handles the draft case naturally: a draft Release exposes no asset URLs to the public CDN, so the HEAD 404s the same way it does for a tag with no Release at all.

A first iteration of this PR went through the API; CI on macOS-beta hit the rate-limit path and failed with 403. Switched to the HEAD-on-CDN approach in `881be04`.

## Other changes

- New private helper `is_release_published(tag)` keeps the 404-vs-error distinction in one place.
- `tests/install_test.rs::test_install_latest_version` previously re-implemented the same buggy "first stable tag" logic locally with `releases::get_all(...)[0]`. Switched it to pass the literal `"latest"` so the install command's standard `resolve_version` path drives the test — exercising the corrected `latest_release()` end-to-end.

## Test plan

- [x] `cargo fmt --all --check` clean.
- [x] `cargo clippy --all --all-features --tests -- -D warnings` clean.
- [x] `cargo test --tests` — 87 pass. Before the fix, `test_get_release_checksum` and `test_install_latest_version` both failed because `latest_release()` returned the in-progress `0.16.3` tag (whose Release was a draft with no uploaded assets).
- [x] Confirmed against the live remote: `HEAD https://github.com/WasmEdge/WasmEdge/releases/download/0.16.3/SHA256SUM` → 404; `HEAD .../releases/download/0.16.2/SHA256SUM` → 302 → 200. With the fix, `latest_release()` returns `0.16.2`.
- [ ] CI pass on the rebased PR — particularly the macOS-beta `Test` job that previously hit the 60/hr API rate limit.