### PR TITLE
fix: stage runtime and plugin installs in secure temp workspaces

### DIFF
--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -88,19 +88,19 @@ impl CommandExecutor for InstallArgs {
 
         let asset = Asset::new(&version, os, arch);
 
-        // Create a dedicated temporary workspace for this installation. This provides isolation
-        // between concurrent installations and ensures consistent handling of different archive
-        // structures. The source path for copying will be either:
-        //   - /tmp/WasmEdge-version-os/ (for archives with root-level files)
-        //   - /tmp/WasmEdge-version-os/WasmEdge-version-os/ (for nested archives)
-        let tmpdir = self
-            .tmpdir
-            .unwrap_or_else(default_tmpdir)
-            .join(&asset.install_name);
-        fs::create_dir_all(&tmpdir).await.inspect_err(
-            |e| tracing::error!(error = %e.to_string(), "Failed to create temporary directory"),
-        )?;
-        tracing::debug!(tmpdir = %tmpdir.display(), "Created temporary directory");
+        // Stage this installation in an isolated temporary workspace with a
+        // randomized name (see `create_temp_workspace`) for isolation between
+        // concurrent installs and consistent handling of archive structures.
+        // The source path for copying is either:
+        //   - <workspace>/ (for archives with root-level files)
+        //   - <workspace>/WasmEdge-<version>-<os>/ (for nested archives)
+        let tmpbase = self.tmpdir.unwrap_or_else(default_tmpdir);
+        let workspace = crate::fs::create_temp_workspace(&tmpbase, &asset.install_name)
+            .inspect_err(
+                |e| tracing::error!(error = %e.to_string(), "Failed to create temporary workspace"),
+            )?;
+        let tmpdir = workspace.path().to_path_buf();
+        tracing::debug!(tmpdir = %tmpdir.display(), "Created temporary workspace directory");
 
         let mut file = ctx
             .client
@@ -204,10 +204,12 @@ impl CommandExecutor for InstallArgs {
         crate::fs::copy_tree(&source_dir, &version_dir).await?;
         tracing::debug!(version_dir = %version_dir.display(), "Copying files to version directory completed");
 
-        fs::remove_dir_all(&tmpdir).await.inspect_err(
-            |e| tracing::error!(error = %e.to_string(), "Failed to clean up temporary directory"),
-        )?;
-        tracing::debug!(tmpdir = %tmpdir.display(), "Cleaned up temporary directory");
+        // The runtime is already copied into `version_dir`, so failing to remove
+        // the staging workspace must not abort the install or skip the symlink/
+        // PATH setup below. Log and continue, leaving the dir for the temp reaper.
+        if let Err(e) = workspace.close() {
+            tracing::warn!(error = %e.to_string(), tmpdir = %tmpdir.display(), "Failed to clean up temporary workspace; continuing");
+        }
 
         tracing::debug!("Creating version symlinks");
         crate::fs::create_version_symlinks(&target_dir, &version.to_string()).await?;

--- a/src/commands/plugin/install.rs
+++ b/src/commands/plugin/install.rs
@@ -43,12 +43,19 @@ pub struct PluginInstallArgs {
 }
 
 impl PluginInstallArgs {
-    fn tmpdir(&self) -> PathBuf {
-        self.tmpdir
-            .clone()
-            .unwrap_or_else(std::env::temp_dir)
-            .join("wasmedgeup")
-            .join("plugins")
+    /// Parent directory under which the per-run randomized staging root is
+    /// created.
+    ///
+    /// Deliberately *not* a predictable subdirectory such as the former
+    /// `<temp>/wasmedgeup/plugins`: `create_dir_all` would follow a symlink a
+    /// local attacker pre-plants at that guessable path, redirecting a
+    /// privileged download/extract outside the temp root (CWE-59). Returning
+    /// the bare (trusted, OS-managed) temp dir — or the user's `--tmpdir` —
+    /// means the only directory created here is the randomized, exclusively
+    /// created root from `create_temp_workspace`, which an attacker cannot
+    /// pre-create.
+    fn staging_parent(&self) -> PathBuf {
+        self.tmpdir.clone().unwrap_or_else(std::env::temp_dir)
     }
 }
 
@@ -107,7 +114,13 @@ impl CommandExecutor for PluginInstallArgs {
         // actually need) rather than the host OS.
         let is_zip = matches!(specs.os.os_type, crate::target::TargetOS::Windows);
 
-        let tmp_root = self.tmpdir();
+        // One exclusive, randomized root per run holds every plugin's staging
+        // directory. It is created directly under the trusted temp dir (not a
+        // predictable path), so a local attacker cannot pre-plant a symlink to
+        // redirect staging. It is removed when `plugins_root` is dropped at the
+        // end of this method or on any early return.
+        let staging_parent = self.staging_parent();
+        let plugins_root = wfs::create_temp_workspace(&staging_parent, "wasmedgeup-plugins")?;
         for plugin in &self.plugins {
             // Keep the plugin's own version typed: when the user passes
             // `plugin@version`, the version may differ from `runtime_version`
@@ -126,12 +139,13 @@ impl CommandExecutor for PluginInstallArgs {
             let url = plugin_asset_url(name, &pver, &os_key, is_zip)?;
             tracing::debug!(%name, %pver, %url, "Downloading plugin");
 
-            let workspace = tmp_root.join(format!("{name}-{pver}"));
-            fs::create_dir_all(&workspace).await?;
+            let workspace =
+                wfs::create_temp_workspace(plugins_root.path(), &format!("{name}-{pver}"))?;
+            let workspace_dir = workspace.path();
             let archive_path = if is_zip {
-                workspace.join("plugin.zip")
+                workspace_dir.join("plugin.zip")
             } else {
-                workspace.join("plugin.tar.gz")
+                workspace_dir.join("plugin.tar.gz")
             };
 
             ctx.client
@@ -163,47 +177,47 @@ impl CommandExecutor for PluginInstallArgs {
                 tracing::debug!(plugin = %name, "Plugin checksum verified");
             }
 
-            wfs::extract_archive(file, &workspace).await?;
+            wfs::extract_archive(file, workspace_dir).await?;
 
-            let paths = find_plugin_shared_objects(&workspace);
-            let found_any = if !paths.is_empty() {
-                for src in paths {
-                    let file_name = src.file_name().unwrap_or_default();
-                    let dest = dest_plugin.join(file_name);
-                    if let Some(parent) = dest.parent() {
-                        if let Err(e) = fs::create_dir_all(parent).await {
-                            tracing::warn!(error = %e, path = %parent.display(), "Failed to create parent directory for plugin");
-                        }
-                    }
-                    if let Err(e) = fs::copy(&src, &dest).await {
-                        tracing::warn!(error = %e, from = %src.display(), to = %dest.display(), "Failed to copy plugin shared object");
-                    } else {
-                        tracing::debug!(from = %src.display(), to = %dest.display(), "Copied plugin shared object");
-                    }
-                }
-                true
-            } else {
-                false
-            };
+            let paths = find_plugin_shared_objects(workspace_dir);
+            let copied = copy_plugin_shared_objects(&paths, &dest_plugin).await;
 
-            if !found_any {
+            if copied == 0 {
+                // Nothing landed in `dest_plugin` — either the archive held no
+                // usable shared object or every copy failed. List the archive
+                // contents to aid diagnosis, then fail instead of reporting a
+                // bogus success. `workspace` (a `TempDir`) is dropped on return,
+                // cleaning up the staging directory.
                 let mut entries: Vec<String> = Vec::new();
-                for e in WalkDir::new(&workspace).into_iter().filter_map(|e| e.ok()) {
+                for e in WalkDir::new(workspace_dir)
+                    .into_iter()
+                    .filter_map(|e| e.ok())
+                {
                     let p = e.path();
                     if p.is_file() {
-                        let rel = p.strip_prefix(&workspace).unwrap_or(p);
+                        let rel = p.strip_prefix(workspace_dir).unwrap_or(p);
                         entries.push(rel.display().to_string());
                     }
                 }
-                tracing::warn!(
-                    root = %workspace.display(),
+                tracing::error!(
+                    plugin = %name,
+                    root = %workspace_dir.display(),
                     entries = ?entries,
-                    "No plugin shared object found in archive; nothing was installed"
+                    "No plugin shared object was installed; archive contents listed for diagnosis"
                 );
+                return Err(Error::PluginNotInstalled {
+                    plugin: name.to_string(),
+                    version: pver.clone(),
+                });
             }
 
-            if let Err(e) = fs::remove_dir_all(&workspace).await {
-                tracing::debug!(error = %e, path = %workspace.display(), "Failed to cleanup workspace");
+            // The shared objects are already copied into `dest_plugin`, so a
+            // cleanup failure must not abort the remaining plugins. Mirror
+            // install.rs and surface it via `close()` rather than letting
+            // `TempDir`'s Drop swallow the error silently.
+            let workspace_path = workspace_dir.to_path_buf();
+            if let Err(e) = workspace.close() {
+                tracing::warn!(error = %e, plugin = %name, path = %workspace_path.display(), "Failed to clean up plugin workspace; continuing");
             }
 
             tracing::info!(plugin = %name, version = %pver, "Installed plugin successfully");
@@ -225,5 +239,108 @@ pub(super) fn select_runtime_version(
         None => Err(Error::VersionNotFound {
             version: "<none installed>".to_string(),
         }),
+    }
+}
+
+/// Copy each discovered plugin shared object in `paths` into `dest_plugin`,
+/// returning how many were copied successfully. Per-object failures are logged
+/// and counted as failures (not aborts) so one unreadable file does not lose
+/// the rest; the caller treats a zero return as "nothing was installed" rather
+/// than reporting a false success.
+async fn copy_plugin_shared_objects(paths: &[PathBuf], dest_plugin: &Path) -> usize {
+    let mut copied = 0usize;
+    for src in paths {
+        let file_name = src.file_name().unwrap_or_default();
+        let dest = dest_plugin.join(file_name);
+        if let Some(parent) = dest.parent() {
+            if let Err(e) = fs::create_dir_all(parent).await {
+                tracing::warn!(error = %e, path = %parent.display(), "Failed to create parent directory for plugin");
+                continue;
+            }
+        }
+        match fs::copy(src, &dest).await {
+            Ok(_) => {
+                copied += 1;
+                tracing::debug!(from = %src.display(), to = %dest.display(), "Copied plugin shared object");
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, from = %src.display(), to = %dest.display(), "Failed to copy plugin shared object");
+            }
+        }
+    }
+    copied
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn staging_parent_has_no_predictable_subdir() {
+        // The staging parent must be the bare temp dir, with no attacker-
+        // guessable subdirectory (e.g. `wasmedgeup/plugins`) that could be
+        // pre-symlinked; the randomized root created inside it via
+        // `create_temp_workspace` provides containment instead.
+        let default = PluginInstallArgs {
+            plugins: vec![],
+            tmpdir: None,
+            runtime: None,
+            path: None,
+            no_verify: false,
+        };
+        assert_eq!(default.staging_parent(), std::env::temp_dir());
+
+        // An explicit --tmpdir is honored verbatim (no subdir appended).
+        let custom = PathBuf::from("/custom/tmp");
+        let overridden = PluginInstallArgs {
+            plugins: vec![],
+            tmpdir: Some(custom.clone()),
+            runtime: None,
+            path: None,
+            no_verify: false,
+        };
+        assert_eq!(overridden.staging_parent(), custom);
+    }
+
+    #[tokio::test]
+    async fn copy_plugin_objects_counts_only_successful_copies() {
+        let src_dir = tempfile::tempdir().unwrap();
+        let dest = tempfile::tempdir().unwrap();
+        let a = src_dir.path().join("liba.so");
+        let b = src_dir.path().join("libb.so");
+        std::fs::write(&a, b"a").unwrap();
+        std::fs::write(&b, b"b").unwrap();
+
+        let copied = copy_plugin_shared_objects(&[a, b], dest.path()).await;
+
+        assert_eq!(copied, 2);
+        assert!(dest.path().join("liba.so").exists());
+        assert!(dest.path().join("libb.so").exists());
+    }
+
+    #[tokio::test]
+    async fn copy_plugin_objects_returns_zero_when_every_copy_fails() {
+        let dest = tempfile::tempdir().unwrap();
+        // Discovery found a candidate, but its source does not exist so the
+        // copy fails. Pre-fix this still reported "Installed successfully"
+        // because the count came from candidates, not successful copies.
+        let missing = dest.path().join("missing-src").join("libplugin.so");
+
+        let copied = copy_plugin_shared_objects(std::slice::from_ref(&missing), dest.path()).await;
+
+        assert_eq!(copied, 0);
+    }
+
+    #[tokio::test]
+    async fn copy_plugin_objects_counts_partial_success() {
+        let src_dir = tempfile::tempdir().unwrap();
+        let dest = tempfile::tempdir().unwrap();
+        let good = src_dir.path().join("libgood.so");
+        std::fs::write(&good, b"ok").unwrap();
+        let missing = src_dir.path().join("libmissing.so"); // never created
+
+        let copied = copy_plugin_shared_objects(&[good, missing], dest.path()).await;
+
+        assert_eq!(copied, 1);
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -88,6 +88,9 @@ pub enum Error {
     #[snafu(display("No plugins specified for installation"))]
     NoPluginsSpecified,
 
+    #[snafu(display("No plugin shared object was installed for '{plugin}' {version}: the archive contained no usable shared object, or every copy failed"))]
+    PluginNotInstalled { plugin: String, version: String },
+
     #[cfg(windows)]
     #[snafu(display("Error: Cannot create symbolic links.\n\nTo enable symlink creation on Windows:\n  1. Run as Administrator, or\n  2. Enable Developer Mode:\n     - Open Windows Settings\n     - Update & Security > For developers\n     - Enable 'Developer Mode'\n"))]
     WindowsSymlinkError { version: String },

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -12,8 +12,74 @@ use std::path::Path;
 use std::os::windows::fs::{symlink_dir, symlink_file};
 
 use std::fs::OpenOptions;
+use tempfile::{Builder, TempDir};
 use tokio::fs;
 use walkdir::WalkDir;
+
+/// Create an isolated temporary workspace with an unpredictable name under
+/// `base`.
+///
+/// Staging an install in a deterministic `base/<install_name>` directory
+/// created with `create_dir_all` is unsafe on a shared temp filesystem: a
+/// local attacker can predict that path and pre-create it (or symlink it
+/// elsewhere) before a privileged install, redirecting download and extract
+/// writes outside the intended boundary (CWE-59 / CWE-377). The guarantee
+/// `tempfile` provides is an *exclusive* directory create: `tempdir_in` issues
+/// a `mkdir`-style create that fails with `EEXIST` and retries a fresh name, so
+/// a directory or symlink an attacker pre-creates at the chosen path is never
+/// adopted or followed. The randomized name is defense-in-depth that makes the
+/// path hard to guess in the first place — but note `tempfile`'s RNG is not
+/// cryptographic, so the safety rests on the exclusive create, not on secrecy
+/// of the name (don't replace this with a predictable name + plain
+/// `create_dir_all`). The returned [`TempDir`] removes itself on drop, cleaning
+/// up even when a later install step fails.
+pub fn create_temp_workspace(base: &Path, install_name: &str) -> Result<TempDir> {
+    // `install_name` is used verbatim as the tempfile name prefix, which
+    // `tempdir_in` joins onto `base`. Anything other than a single *normal*
+    // path component would let the workspace be created outside `base`
+    // (plugin names are unvalidated user input), defeating the containment
+    // this helper provides, so require exactly one normal component. A bare
+    // separator check is not enough: `../../evil` escapes via `..`, and on
+    // Windows a drive-relative prefix like `C:evil` (which
+    // `std::path::is_separator` does *not* flag) makes `base.join(..)` discard
+    // `base` entirely. Reject all of those rather than silently escaping the
+    // staging boundary.
+    let mut components = Path::new(install_name).components();
+    let is_single_normal_component = matches!(
+        components.next(),
+        Some(std::path::Component::Normal(name)) if name == std::ffi::OsStr::new(install_name)
+    ) && components.next().is_none();
+    if !is_single_normal_component {
+        return Err(Error::InvalidPath {
+            path: install_name.to_string(),
+            reason: "temp workspace name must be a single path component".to_string(),
+        });
+    }
+
+    std::fs::create_dir_all(base).map_err(|source| Error::Io {
+        action: "create temp workspace base directory".to_string(),
+        path: base.display().to_string(),
+        source,
+    })?;
+
+    let prefix = format!("{install_name}-");
+    let mut builder = Builder::new();
+    builder.prefix(&prefix);
+    // Stage privileged, not-yet-verified downloads in a private directory so
+    // other local users on a shared temp filesystem cannot read them; tempfile
+    // otherwise creates the workspace with the process umask (typically 0755).
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        builder.permissions(std::fs::Permissions::from_mode(0o700));
+    }
+    let workspace = builder.tempdir_in(base).map_err(|source| Error::Io {
+        action: "create temp workspace".to_string(),
+        path: base.display().to_string(),
+        source,
+    })?;
+    Ok(workspace)
+}
 
 pub fn can_write_to_directory(path: &Path) -> bool {
     let test_file = path.join(".wasmedgeup_write_test");
@@ -558,5 +624,141 @@ mod tests {
         );
         let resolved = std::fs::read_link(&to_link).expect("dest should be a readable symlink");
         assert_eq!(resolved, real_target);
+    }
+}
+
+#[cfg(test)]
+mod temp_workspace_tests {
+    use super::*;
+
+    /// A local attacker on a shared temp filesystem can predict the legacy
+    /// workspace path (`<base>/<install_name>`) and pre-create it before a
+    /// privileged install to redirect download/extract writes (CWE-59 /
+    /// CWE-377). Each call must instead yield a fresh, unique directory that
+    /// never reuses that predictable path.
+    #[test]
+    fn temp_workspace_is_unpredictable_and_not_reused() {
+        let base = tempfile::tempdir().unwrap();
+        let install_name = "WasmEdge-0.14.1-Linux";
+
+        // Simulate an attacker pre-creating the predictable path.
+        let predictable = base.path().join(install_name);
+        std::fs::create_dir_all(&predictable).unwrap();
+
+        let ws1 = create_temp_workspace(base.path(), install_name).unwrap();
+        let ws2 = create_temp_workspace(base.path(), install_name).unwrap();
+
+        assert_ne!(ws1.path(), predictable.as_path());
+        assert_ne!(ws2.path(), predictable.as_path());
+        assert_ne!(ws1.path(), ws2.path());
+        assert!(ws1.path().starts_with(base.path()));
+        assert!(ws1.path().is_dir());
+        assert_eq!(std::fs::read_dir(ws1.path()).unwrap().count(), 0);
+    }
+
+    /// CWE-59 regression: when an attacker pre-creates the legacy predictable
+    /// path (`<base>/<install_name>`) as a symlink into a directory they
+    /// control, the helper must neither use nor follow it. The defense is that
+    /// the workspace is staged under a fresh randomized sibling created with an
+    /// exclusive `mkdir`, so the planted symlink is never on the write path.
+    /// This test pins that: the returned workspace is a real directory distinct
+    /// from the symlink, the symlink is left intact (not followed or clobbered
+    /// — a predictable-path regression would do one of those), and an actual
+    /// write lands inside `base` rather than leaking through into the attacker's
+    /// directory.
+    #[cfg(unix)]
+    #[test]
+    fn temp_workspace_write_is_contained_despite_precreated_symlink() {
+        let base = tempfile::tempdir().unwrap();
+        let attacker_target = tempfile::tempdir().unwrap();
+        let install_name = "WasmEdge-0.14.1-Linux";
+
+        let predictable = base.path().join(install_name);
+        std::os::unix::fs::symlink(attacker_target.path(), &predictable).unwrap();
+
+        let ws = create_temp_workspace(base.path(), install_name).unwrap();
+
+        // The helper must avoid the predictable path entirely: a different path
+        // AND a still-intact symlink prove it neither adopted nor followed it
+        // (the latter would have replaced the symlink with a real directory).
+        assert_ne!(ws.path(), predictable.as_path());
+        assert!(
+            std::fs::symlink_metadata(&predictable)
+                .unwrap()
+                .file_type()
+                .is_symlink(),
+            "the planted symlink at the legacy path must be left untouched"
+        );
+
+        let staged = ws.path().join("payload");
+        std::fs::write(&staged, b"runtime bytes").unwrap();
+
+        let base_canon = base.path().canonicalize().unwrap();
+        let attacker_canon = attacker_target.path().canonicalize().unwrap();
+        let ws_canon = ws.path().canonicalize().unwrap();
+
+        assert!(ws_canon.starts_with(&base_canon));
+        assert!(!ws_canon.starts_with(&attacker_canon));
+        assert!(staged.canonicalize().unwrap().starts_with(&base_canon));
+        assert_eq!(
+            std::fs::read_dir(attacker_target.path()).unwrap().count(),
+            0,
+            "write leaked through the pre-created symlink into the attacker's directory"
+        );
+    }
+
+    /// `create_temp_workspace` must create `base` (and any missing parents) on
+    /// first use: the real plugin staging root (`<temp>/wasmedgeup/plugins`)
+    /// usually does not exist on a fresh machine, so the helper has to
+    /// materialize it. A regression dropping the `create_dir_all(base)` step
+    /// would still pass the tests above (which pass an already-existing `base`)
+    /// yet break the first-ever install with ENOENT from `tempdir_in`.
+    #[test]
+    fn temp_workspace_creates_missing_base() {
+        let root = tempfile::tempdir().unwrap();
+        let base = root.path().join("wasmedgeup").join("plugins");
+        assert!(!base.exists());
+
+        let ws = create_temp_workspace(&base, "wasi_nn-0.14.1").unwrap();
+
+        assert!(base.is_dir());
+        assert!(ws.path().starts_with(&base));
+        assert!(ws.path().is_dir());
+    }
+
+    /// Plugin names are unvalidated user input (`PluginVersion` only splits on
+    /// `@`), and the name is used verbatim as the tempfile prefix that
+    /// `tempdir_in` joins onto `base`. A name that is not a single normal path
+    /// component would otherwise create the workspace outside the staging root,
+    /// so the helper must reject every such escape: a path separator
+    /// (`../../evil`), a `.`/`..` element, and — on Windows — a drive-relative
+    /// prefix like `C:evil` that `std::path::is_separator` would miss.
+    #[test]
+    fn temp_workspace_rejects_non_component_names() {
+        let base = tempfile::tempdir().unwrap();
+
+        for bad in ["../../evil", "..", ".", "a/b", "trailing/"] {
+            let err = create_temp_workspace(base.path(), bad).unwrap_err();
+            assert!(
+                matches!(err, Error::InvalidPath { .. }),
+                "expected InvalidPath for {bad:?}, got {err:?}"
+            );
+        }
+
+        // A drive-relative prefix has no separator but still escapes `base` on
+        // Windows (`base.join("C:evil-...")` discards `base`); it must be
+        // rejected there. On Unix `:` is an ordinary filename character, so the
+        // same string is a legitimate single component and stays accepted.
+        #[cfg(windows)]
+        {
+            let err = create_temp_workspace(base.path(), "C:evil").unwrap_err();
+            assert!(
+                matches!(err, Error::InvalidPath { .. }),
+                "expected InvalidPath for a drive-relative name, got {err:?}"
+            );
+        }
+
+        // A normal single-component name is still accepted.
+        assert!(create_temp_workspace(base.path(), "wasi_nn-0.14.1").is_ok());
     }
 }


### PR DESCRIPTION
## Why is this needed?

Both `install` and `plugin install` staged downloads in **predictable** temp
paths created with `create_dir_all`:

- runtime: `<tmp>/<install_name>`
- plugins: `<tmp>/wasmedgeup/plugins/<name>-<version>`

On a shared temp filesystem a local attacker can pre-create or symlink those
guessable paths before a (potentially privileged) install. `create_dir_all`
adopts an existing directory and follows a planted symlink, redirecting the
download/extract writes outside the intended staging boundary — symlink
following (CWE-59) / insecure temporary file creation (CWE-377).

Separately, `plugin install` derived its success status from the number of
shared objects *discovered* in the archive, not the number actually *copied*
into the destination. A plugin whose every copy failed still logged
"Installed plugin successfully" and exited 0 — a silent failure.

## What does this PR change?

- **New `create_temp_workspace(base, name)` helper (`src/fs.rs`)** — stages
  under a randomized name created with tempfile's exclusive `mkdir`, so a
  pre-planted directory or symlink is never adopted or followed. Restricts the
  staging dir to `0700` on Unix, creates `base` if missing, and rejects names
  that aren't a single *normal* path component (blocking `..`, path separators,
  and Windows drive-relative prefixes like `C:evil`). Returns a `TempDir` that
  self-cleans on drop.
- **`install`** now stages in that workspace instead of `<tmp>/<install_name>`.
  The runtime is copied into the version dir before cleanup, so a
  staging-cleanup failure is now logged and the install *continues* (symlink /
  PATH setup is no longer skipped); the workspace is otherwise removed on any
  early return.
- **`plugin install`** creates one exclusive, randomized per-run root directly
  under the trusted temp dir (the predictable `wasmedgeup/plugins` subdir is
  gone) and stages each plugin beneath it. It now counts *successful* copies via
  a new `copy_plugin_shared_objects` helper and returns the new
  `PluginNotInstalled` error (non-zero exit) when none land, logging the archive
  contents to aid diagnosis. Cleanup failures surface via `close()` instead of
  being swallowed by `TempDir`'s `Drop`.
- **New error variant** `Error::PluginNotInstalled { plugin, version }`.

## How has this been tested?

`cargo test --lib` → 50 passed, 0 failed. New unit tests added:

- workspace is unpredictable and never reuses the legacy path
- (Unix) a write stays contained even when the legacy path is a pre-planted
  symlink — the symlink is left intact and nothing leaks into the attacker's
  directory
- `base` is created on first use
- non-single-component names are rejected (`../../evil`, `..`, `.`, `a/b`,
  `trailing/`, plus `C:evil` on Windows)
- copy helper counts only successful copies (all-success, all-fail → 0, partial)
- `staging_parent` exposes no predictable subdir and honors `--tmpdir` verbatim

## Anything else?

This is a security hardening change with no user-facing CLI surface changes;
`--tmpdir` still works (it's now used as the staging *parent*, with the
randomized root created inside it).