### PR TITLE
ci: remove super-linter SHA detection work-around

### DIFF
--- a/.github/workflows/superlinter.yml
+++ b/.github/workflows/superlinter.yml
@@ -30,14 +30,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Work around super-linter
-        shell: bash
-        run: |
-          # Work-around for SHA detection
-          # https://github.com/super-linter/super-linter/issues/6316#issuecomment-2510205626
-          if [[ '${{ github.event_name }}' == 'pull_request' ]]; then
-            echo 'GITHUB_BEFORE_SHA=${{ github.event.pull_request.base.sha }}' >> "${GITHUB_ENV}"
-          fi
       - name: Run Super Linter
         uses: super-linter/super-linter@9e863354e3ff62e0727d37183162c4a88873df41 # v8.6.0
         env:


### PR DESCRIPTION
Removes the legacy `GITHUB_BEFORE_SHA` work-around step from `superlinter.yml`. The underlying SHA detection bug was fixed upstream ([super-linter#6316](https://github.com/super-linter/super-linter/issues/6316)), so the step is dead weight.

This mirrors [WasmEdge/cpp-plugins#8](https://github.com/WasmEdge/cpp-plugins/pull/8), which removed the same work-around — that repo has been running super-linter (currently v8.6.0, same as here) with `VALIDATE_ALL_CODEBASE: false` and no `GITHUB_BEFORE_SHA` ever since, with changed-file detection working correctly (most recently verified on [cpp-plugins#43](https://github.com/WasmEdge/cpp-plugins/pull/43)).

This PR's own Super-Linter run exercises the pull_request code path the work-around used to cover, so a green check here validates the removal.

---

🤖 Generated by Claude Fable 5 with [Claude Code](https://claude.com/claude-code)