### PR TITLE
chore: ignore RUSTSEC-2026-0173 (unmaintained proc-macro-error2)

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,9 @@
+# cargo-audit configuration — https://github.com/rustsec/rustsec/tree/main/cargo-audit
+[advisories]
+# RUSTSEC-2026-0173: proc-macro-error2 unmaintained (informational, not a vulnerability).
+# Phantom transitive dep behind jiff's optional, disabled `defmt` feature:
+#   gix -> gix-date -> jiff -> defmt (optional, off) -> defmt-macros -> proc-macro-error2
+# Never compiled into the binary (`cargo tree -e normal -i proc-macro-error2` prints nothing),
+# and latest jiff/defmt-macros still pull it in, so it cannot be removed by upgrading.
+# Drop this entry once upstream defmt-macros migrates off proc-macro-error2.
+ignore = ["RUSTSEC-2026-0173"]


### PR DESCRIPTION
## Summary

Resolves the RUSTSEC-2026-0173 advisory reported in #299 by ignoring it in the
cargo-audit configuration.

`proc-macro-error2` is flagged as **unmaintained** — an informational advisory,
not a security vulnerability (`cargo audit` reports `vulnerabilities.count = 0`;
it only appears under `warnings.unmaintained`). It is **never compiled into the
binary**: it enters only as a phantom transitive dependency behind `jiff`'s
optional, disabled `defmt` feature:

```
gix -> gix-date -> jiff -> defmt (optional, off) -> defmt-macros -> proc-macro-error2
```

`cargo tree -e normal -i proc-macro-error2` (including `--target all`) prints
nothing, confirming it is absent from the actual build graph. The latest `jiff`
(0.2.29) and `defmt-macros` (1.1.0) still reference it, so it cannot be removed
by upgrading, nor can the suggested alternatives (manyhow /
proc-macro2-diagnostics) be adopted from our side — that is upstream's call.

## Change

Add `.cargo/audit.toml` with `ignore = ["RUSTSEC-2026-0173"]`.

Verified locally with cargo-audit 0.22.1: after this change `cargo audit` no
longer emits the warning (its `warnings` set becomes empty), so the scheduled
`rustsec/audit-check` job will stop re-filing this issue. The ignore entry is
documented inline and should be dropped once upstream `defmt-macros` migrates
off `proc-macro-error2`.

Closes #299

---

This contribution was developed with assistance from Claude (Anthropic).
