### PR TITLE
ci: reduce redundant workflow jobs

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -9,6 +9,10 @@ inputs:
   target:
     description: Build target name, such as 'x86_64-unknown-linux-gnu', 'aarch64-apple-darwin', or 'x86_64-pc-windows-msvc'
     required: false
+  cache:
+    description: Enable sccache for Rust compilation
+    required: false
+    default: "true"
 
 runs:
   using: composite
@@ -25,8 +29,10 @@ runs:
       run: rustup target add ${{ inputs.target }}
 
     - uses: mozilla-actions/sccache-action@v0.0.10
+      if: "${{ inputs.cache == 'true' }}"
 
     - name: Setup rust cache variables
+      if: "${{ inputs.cache == 'true' }}"
       shell: bash
       run: |
         echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV

--- a/.github/workflows/audit_check.yml
+++ b/.github/workflows/audit_check.yml
@@ -1,7 +1,12 @@
 name: Security audit
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   push:
+    branches: [master]
     paths:
       - ".github/workflows/audit_check.yml"
       - "**/Cargo.toml"

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -7,6 +7,11 @@
 #
 # Source repository: https://github.com/actions/dependency-review-action
 name: 'Dependency Review'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 on: [pull_request]
 
 permissions:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,7 +1,7 @@
 name: Rust
 
 concurrency:
-  group: ${{ github.repository }}-${{ github.head_ref || github.sha }}-${{ github.workflow }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 on:
@@ -17,6 +17,9 @@ on:
       - ".github/ISSUE_TEMPLATE/**"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   fmt:
     runs-on: ubuntu-latest
@@ -31,6 +34,8 @@ jobs:
 
       - name: Setup rust toolchain
         uses: ./.github/actions/setup-rust
+        with:
+          cache: "false"
 
       - name: Check formatting (rustfmt)
         run: cargo fmt --all --check
@@ -51,29 +56,6 @@ jobs:
 
       - name: Run clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
-
-  build:
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        toolchain: [stable, beta]
-    name: Build test
-    runs-on: ${{ matrix.os }}
-    steps:
-      - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
-        with:
-          egress-policy: audit
-
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-      - name: Setup rust toolchain
-        uses: ./.github/actions/setup-rust
-        with:
-          toolchain: ${{ matrix.toolchain }}
-
-      - name: Build test
-        run: cargo check --profile=dev
 
   test:
     strategy:
@@ -111,10 +93,6 @@ jobs:
             os: ubuntu-latest
           - target: x86_64-apple-darwin
             os: macos-latest
-          - target: aarch64-apple-darwin
-            os: macos-latest
-          - target: x86_64-pc-windows-msvc
-            os: windows-latest
     name: Cross build (${{ matrix.target }})
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/superlinter.yml
+++ b/.github/workflows/superlinter.yml
@@ -1,6 +1,10 @@
 ---
 name: Super-Linter
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 on:
   push:
     branches: [master]

--- a/src/shell_utils/unix.rs
+++ b/src/shell_utils/unix.rs
@@ -38,7 +38,7 @@ pub fn setup_path(install_dir: &Path) -> Result<()> {
             written.push(env_script);
         }
         let source_line = shell.source_line(install_dir);
-        let source_line_with_newline = format!("\n{}", &source_line);
+        let source_line_with_newline = format!("\n{}", source_line);
 
         for rc in shell.effective_rc_files() {
             let line_to_write: &str = match read_to_string(&rc) {


### PR DESCRIPTION
## Which GitHub issue does this PR close?

N/A — CI maintenance.

## Why is this needed?

The Rust workflow currently repeats validation that is already covered by the full test matrix and includes two "cross" entries that are native on the current GitHub-hosted runner architectures. Superseded pull-request runs also continue consuming runner time.

Based on a recent complete run, this is expected to reduce the Rust workflow from 20 jobs to 12 jobs and from about 56.7 to 33.8 runner-minutes (approximately 40%), while preserving the stable/beta tests across Linux, macOS, and Windows plus four genuine cross-compilation targets.

## What does this PR change?

- Removes the six-job `cargo check` matrix because the six test jobs compile the same stable/beta and OS combinations.
- Removes native entries from the cross matrix:
  - `aarch64-apple-darwin` on the ARM64 `macos-latest` runner.
  - `x86_64-pc-windows-msvc` on the x64 `windows-latest` runner.
- Adds cancellation concurrency to Rust, audit, dependency-review, and Super-Linter workflows.
- Restricts push-triggered dependency auditing to `master`; pull requests remain covered.
- Disables sccache for the formatting-only job.
- Adds explicit read-only repository permissions to the Rust workflow.
- Includes the one-line Rust 1.97 Clippy cleanup needed for this branch to remain independently green.

## How has this been tested?

- `actionlint -color`
- `cargo fmt --all --check`
- `cargo +1.97.0 clippy --locked --offline --all-targets --all-features -- -D warnings`
- `cargo +1.97.0 test --locked --offline --profile=dev`
- `git diff --check origin/master...HEAD`

## Anything else?

The Clippy cleanup is also present in #306. Keeping it here makes this CI-only branch independently testable; if #306 merges first, rebasing this branch will naturally drop the duplicate commit.

AI assistance was used to inspect workflow overlap, prepare the changes, and run validation.